### PR TITLE
Remove call to logging.basicConfig in the module

### DIFF
--- a/simple_parsing/logging_utils.py
+++ b/simple_parsing/logging_utils.py
@@ -1,12 +1,6 @@
 import logging
 from pathlib import Path
 
-logging.basicConfig(
-    format='%(levelname)-8s [%(name)s:%(lineno)d] %(message)s',
-    datefmt='%Y-%m-%d:%H:%M:%S',
-    level=logging.INFO,
-)
-
 def get_logger(name: str) -> logging.Logger:
         """ Gets a logger for the given file. Sets a nice default format. 
         TODO: figure out if we should add handlers, etc. 


### PR DESCRIPTION
Otherwise, code using this library will be forced to use this handler and
it potentially will generate duplicated log lines in the output, as both
the user and these library handlers are installed. This is actually my case. 

basicConfig method should be only called by the library user (e.g. in the main function), and never inside the
module of the library itself. 

This can be seen as a first step for issue https://github.com/lebrice/SimpleParsing/issues/21