### PR TITLE
Add the dest to the option strings

### DIFF
--- a/examples/simple/basic.py
+++ b/examples/simple/basic.py
@@ -25,19 +25,19 @@ HParams(num_layers=4, num_units=64, optimizer='ADAM', learning_rate=0.001)
 
 parser.print_help()
 expected += """
-usage: basic.py [-h] [--num_layers int] [--num_units int]
-                    [--optimizer str] [--learning_rate float]
+usage: basic.py [-h] [--num_layers int] [--num_units int] [--optimizer str]
+                [--learning_rate float]
 
 optional arguments:
   -h, --help            show this help message and exit
 
 HParams ['hparams']:
-  Set of options for the training of a Model.
+   Set of options for the training of a Model.
 
-  --num_layers int
-  --num_units int
-  --optimizer str
-  --learning_rate float
+  --num_layers int, --hparams.num_layers int
+  --num_units int, --hparams.num_units int
+  --optimizer str, --hparams.optimizer str
+  --learning_rate float, --hparams.learning_rate float
 """
 
 
@@ -45,11 +45,11 @@ print(parser.equivalent_argparse_code())
 expected += """
 parser = ArgumentParser()
 
-group = parser.add_argument_group(title="HParams ['hparams']", description=" Set of options for the training of a Model.")
-group.add_argument(*['--num_layers'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_layers', 'default': 4})
-group.add_argument(*['--num_units'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_units', 'default': 64})
-group.add_argument(*['--optimizer'], **{'type': str, 'help': None, 'required': False, 'dest': 'hparams.optimizer', 'default': 'ADAM'})
-group.add_argument(*['--learning_rate'], **{'type': float, 'help': None, 'required': False, 'dest': 'hparams.learning_rate', 'default': 0.001})
+group = parser.add_argument_group(title="HParams ['hparams']", description="Set of options for the training of a Model.")
+group.add_argument(*['--num_layers', '--hparams.num_layers'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_layers', 'default': 4})
+group.add_argument(*['--num_units', '--hparams.num_units'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_units', 'default': 64})
+group.add_argument(*['--optimizer', '--hparams.optimizer'], **{'type': str, 'help': None, 'required': False, 'dest': 'hparams.optimizer', 'default': 'ADAM'})
+group.add_argument(*['--learning_rate', '--hparams.learning_rate'], **{'type': float, 'help': None, 'required': False, 'dest': 'hparams.learning_rate', 'default': 0.001})
 
 args = parser.parse_args()
 print(args)

--- a/examples/simple/choice.py
+++ b/examples/simple/choice.py
@@ -22,17 +22,16 @@ HParams(num_layers=4, num_units=64, optimizer='ADAM', learning_rate=0.001)
 parser.print_help()
 expected += """
 usage: choice.py [-h] [--num_layers int] [--num_units int]
-                           [--optimizer {ADAM,SGD,RMSPROP}]
-                           [--learning_rate float]
+                 [--optimizer {ADAM,SGD,RMSPROP}] [--learning_rate float]
 
 optional arguments:
   -h, --help            show this help message and exit
 
 HParams ['hparams']:
-  Set of options for the training of a Model.
+   Set of options for the training of a Model.
 
-  --num_layers int
-  --num_units int
-  --optimizer {ADAM,SGD,RMSPROP}
-  --learning_rate float
+  --num_layers int, --hparams.num_layers int
+  --num_units int, --hparams.num_units int
+  --optimizer {ADAM,SGD,RMSPROP}, --hparams.optimizer {ADAM,SGD,RMSPROP}
+  --learning_rate float, --hparams.learning_rate float
 """

--- a/examples/simple/help.py
+++ b/examples/simple/help.py
@@ -71,12 +71,16 @@ HParams ['hparams']:
       ./simple_parsing/utils.py
       
 
-  --num_layers int      Number of layers in the model. (default: 4)
-  --num_units int       Number of units (neurons) per layer. (default: 64)
-  --optimizer str       Which optimizer to use. (default: ADAM)
-  --learning_rate float
+  --num_layers int, --hparams.num_layers int
+                        Number of layers in the model. (default: 4)
+  --num_units int, --hparams.num_units int
+                        Number of units (neurons) per layer. (default: 64)
+  --optimizer str, --hparams.optimizer str
+                        Which optimizer to use. (default: ADAM)
+  --learning_rate float, --hparams.learning_rate float
                         Learning_rate used by the optimizer. (default: 0.001)
-  --alpha float         A detailed description of this new 'alpha' parameter,
+  --alpha float, --hparams.alpha float
+                        A detailed description of this new 'alpha' parameter,
                         which can potentially span multiple lines. (default:
                         0.05)
 """

--- a/examples/simple/inheritance.py
+++ b/examples/simple/inheritance.py
@@ -47,11 +47,12 @@ MAML ['hparams']:
   Overwrites some of the default values and adds new arguments/attributes.
       
 
-  --num_layers int
-  --num_units int
-  --optimizer str
-  --learning_rate float
-  --name str            method (default: MAML)
+  --num_layers int, --hparams.num_layers int
+  --num_units int, --hparams.num_units int
+  --optimizer str, --hparams.optimizer str
+  --learning_rate float, --hparams.learning_rate float
+  --name str, --hparams.name str
+                        method (default: MAML)
 """
 
 
@@ -60,11 +61,11 @@ expected += """
 parser = ArgumentParser()
 
 group = parser.add_argument_group(title="MAML ['hparams']", description="Overwrites some of the default values and adds new arguments/attributes.")
-group.add_argument(*['--num_layers'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_layers', 'default': 6})
-group.add_argument(*['--num_units'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_units', 'default': 128})
-group.add_argument(*['--optimizer'], **{'type': str, 'help': None, 'required': False, 'dest': 'hparams.optimizer', 'default': 'ADAM'})
-group.add_argument(*['--learning_rate'], **{'type': float, 'help': None, 'required': False, 'dest': 'hparams.learning_rate', 'default': 0.001})
-group.add_argument(*['--name'], **{'type': str, 'help': 'method', 'required': False, 'dest': 'hparams.name', 'default': 'MAML'})
+group.add_argument(*['--num_layers', '--hparams.num_layers'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_layers', 'default': 6})
+group.add_argument(*['--num_units', '--hparams.num_units'], **{'type': int, 'help': None, 'required': False, 'dest': 'hparams.num_units', 'default': 128})
+group.add_argument(*['--optimizer', '--hparams.optimizer'], **{'type': str, 'help': None, 'required': False, 'dest': 'hparams.optimizer', 'default': 'ADAM'})
+group.add_argument(*['--learning_rate', '--hparams.learning_rate'], **{'type': float, 'help': None, 'required': False, 'dest': 'hparams.learning_rate', 'default': 0.001})
+group.add_argument(*['--name', '--hparams.name'], **{'type': str, 'help': 'method', 'required': False, 'dest': 'hparams.name', 'default': 'MAML'})
 
 args = parser.parse_args()
 print(args)

--- a/examples/simple/option_strings.py
+++ b/examples/simple/option_strings.py
@@ -29,8 +29,8 @@ optional arguments:
 HParams ['hparams']:
    Set of options for the training of a Model. 
 
-  -n int, --num_layers int
-  -u int, --num_units int
-  -o str, --opt str, --optimizer str
-  -lr float, --learning_rate float
+  -n int, --num_layers int, --hparams.num_layers int
+  -u int, --num_units int, --hparams.num_units int
+  -o str, --opt str, --optimizer str, --hparams.optimizer str
+  -lr float, --learning_rate float, --hparams.learning_rate float
 """

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -27,6 +27,8 @@ def set_prog_name():
     yield set_prog
     sys.argv = argv
 
+import textwrap
+
 
 @pytest.fixture
 def assert_equals_stdout(capsys):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ print(sys.version_info)
 
 setuptools.setup(
     name="simple_parsing",
-    version="0.0.11.post13",
+    version="0.0.11.post14",
     author="Fabrice Normandin",
     author_email="fabrice.normandin@gmail.com",
     description="A small utility for simplifying and cleaning up argument parsing scripts.",

--- a/simple_parsing/helpers/serialization/encoding.py
+++ b/simple_parsing/helpers/serialization/encoding.py
@@ -91,7 +91,6 @@ def encode_list(obj: Iterable) -> Sequence:
 @encode.register(dict)
 @encode.register(Mapping)
 def encode_dict(obj: Mapping) -> Dict:
-    logger.debug(f"Encoding dict")
     constructor = type(obj)
     result = constructor()
     for k, v in obj.items():

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -27,6 +27,7 @@ class ArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args,
                  conflict_resolution: ConflictResolution=ConflictResolution.AUTO,
                  add_option_string_dash_variants: bool=False,
+                 add_dest_to_option_strings: bool=True,
                  formatter_class: Type[HelpFormatter]=SimpleHelpFormatter,
                  **kwargs):
         """Creates an ArgumentParser instance.
@@ -36,17 +37,32 @@ class ArgumentParser(argparse.ArgumentParser):
         - conflict_resolution : ConflictResolution, optional
 
             What kind of prefixing mechanism to use when reusing dataclasses
-            (argument groups)
+            (argument groups).
             For more info, check the docstring of the `ConflictResolution` Enum.
 
         - add_option_string_dash_variants : bool, optional
 
             Wether or not to add option_string variants where the underscores in
             attribute names are replaced with dashes.
-            For example, when set to `True`, "--no-cache" and "--no_cache" could
+            For example, when set to `True`, "--no-cache" and "--no_cache" can
             both be used to point to the same attribute `no_cache` on some
             dataclass.
         
+        - add_dest_to_option_strings: bool, optional
+
+            Wether or not to add the `dest` of each field to the list of option
+            strings for the argument.
+            When True (default), each field can be referenced using either the
+            auto-generated option string or the full 'destination' of the field
+            in the resulting namespace.
+            When False, only uses the auto-generated option strings.
+            
+            The auto-generated option strings are usually just the field names,
+            except when there are multiple arguments with the same name. In this
+            case, the conflicts are resolved as determined by the value of
+            `conflict_resolution` and each field ends up with a unique option
+            string.
+
         - formatter_class : Type[HelpFormatter], optional
 
             The formatter class to use. By default, uses
@@ -68,6 +84,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         self._preprocessing_done: bool = False
         FieldWrapper.add_dash_variants = add_option_string_dash_variants
+        FieldWrapper.add_dest_to_option_strings = add_dest_to_option_strings
 
     @overload
     def add_arguments(self, dataclass: Type[Dataclass], dest: str, prefix: str="", default: Dataclass=None):

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -38,6 +38,8 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
     # TODO: This can often make "--help" messages a bit crowded
     add_dash_variants: ClassVar[bool] = False
 
+    # Wether to add the `dest` to the list of option strings.
+    add_dest_to_option_strings: ClassVar[bool] = True
 
     def __init__(self, field: dataclasses.Field, parent: Any = None, prefix: str=""):
         super().__init__(wrapped=field, name=field.name)
@@ -436,6 +438,11 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
             ]
             options.extend(additional_options)
             dashes.extend(additional_dashes)
+        
+        if type(self).add_dest_to_option_strings:
+            dashes.append("-" if len(self.dest) == 1 else "--")
+            options.append(self.dest)
+        
         # remove duplicates by creating a set.
         option_strings = set(
             f"{dash}{option}" for dash, option in zip(dashes, options)


### PR DESCRIPTION
Addresses/fixes #27 by adding the option of having the 'full destination' of each field as one of the option strings.

This behaviour is on by default, and can be turned off by with the  `add_dest_to_option_strings` argument of the `ArgumentParser` object.


Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>