### PR TITLE
Turned off the subparser re-ordering by default

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ print(sys.version_info)
 
 setuptools.setup(
     name="simple_parsing",
-    version="0.0.11.post15",
+    version="0.0.11.post16",
     author="Fabrice Normandin",
     author_email="fabrice.normandin@gmail.com",
     description="A small utility for simplifying and cleaning up argument parsing scripts.",

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -148,7 +148,8 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def parse_known_args(self,
                          args: Sequence[Text] = None,
-                         namespace: Namespace = None):
+                         namespace: Namespace = None,
+                         attempt_to_reorder: bool=False):
         # NOTE: since the usual ArgumentParser.parse_args() calls
         # parse_known_args, we therefore just need to overload the
         # parse_known_args method to support both.
@@ -162,7 +163,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         parsed_args, unparsed_args = super().parse_known_args(args, namespace)
 
-        if unparsed_args and self._subparsers:
+        if unparsed_args and self._subparsers and attempt_to_reorder:
             logger.warning(
                 f"Unparsed arguments when using subparsers. Will "
                 f"attempt to automatically re-order the unparsed arguments "
@@ -172,7 +173,6 @@ class ArgumentParser(argparse.ArgumentParser):
             # Simply 'cycle' the args to the right ordering.
             new_start_args = args[index_in_start:] + args[:index_in_start]
             parsed_args, unparsed_args = super().parse_known_args(new_start_args)
-
 
         parsed_args = self._postprocessing(parsed_args)
         return parsed_args, unparsed_args

--- a/test/test_subparsers.py
+++ b/test/test_subparsers.py
@@ -184,13 +184,13 @@ def test_subparser_rest_of_args_go_to_parent():
         foo: bool = simple_parsing.flag(False)
         income: float = 35_000.
 
-    p = Parent.setup("pet --kind fish --foo --income 10_000")
+    p = Parent.setup("pet --kind fish --foo --income 10_000", parse_known_args=True, attempt_to_reorder=True)
     assert p == Parent(family=Pet(kind="fish"), foo=True, income=10_000.0)
 
-    p = Parent.setup("--income 10_000 pet --kind fish --foo")
+    p = Parent.setup("--income 10_000 pet --kind fish --foo", parse_known_args=True, attempt_to_reorder=True)
     assert p == Parent(family=Pet(kind="fish"), foo=True, income=10_000.0)
 
-    p = Parent.setup("--income 10_000 --foo pet --kind fish")
+    p = Parent.setup("--income 10_000 --foo pet --kind fish", parse_known_args=True, attempt_to_reorder=True)
     assert p == Parent(family=Pet(kind="fish"), foo=True, income=10_000.0)
 
 
@@ -212,7 +212,7 @@ def test_mixing_the_ordering():
         foo: bool = False
         income: float = 35_000.
 
-    p = Parent.setup("--income 10_000 pet --foo --kind fish")
+    p = Parent.setup("--income 10_000 pet --foo --kind fish", parse_known_args=True, attempt_to_reorder=True)
     assert p == Parent(family=Pet(kind="fish"), foo=True, income=10_000.0)
 
 @xfail(reason="TODO")
@@ -232,7 +232,7 @@ def test_mixing_the_ordering_all_have_defaults():
         foo: bool = False
         income: float = 35_000.
 
-    p = Parent.setup("--income 10_000 pet --foo --kind fish")
+    p = Parent.setup("--income 10_000 pet --foo --kind fish", parse_known_args=True, attempt_to_reorder=True)
     assert p == Parent(family=Pet(kind="fish"), foo=True, income=10_000.0)
 
 
@@ -254,7 +254,7 @@ def test_argparse_version_giving_extra_args_to_parent():
     assert args == (Namespace(foo=3, bar=2, baz=3), ['--foo', '1'])
 
 
-def test_argparse_version_giving_extra_args_to_parent():
+def test_simpleparse_version_giving_extra_args_to_parent():
     parser = simple_parsing.ArgumentParser()
     parser.add_argument("--foo", type=int, default=3)
     assert not parser._subparsers
@@ -267,7 +267,7 @@ def test_argparse_version_giving_extra_args_to_parent():
     args = parser.parse_args("--foo 1 boo --bar 2 --baz 3".split())
     assert args == Namespace(foo=1, bar=2, baz=3)
 
-    args = parser.parse_known_args("boo --bar 2 --baz 3 --foo 1".split())
+    args = parser.parse_known_args("boo --bar 2 --baz 3 --foo 1".split(), attempt_to_reorder=True)
     assert args == (Namespace(foo=1, bar=2, baz=3), [])
 
 

--- a/test/testutils.py
+++ b/test/testutils.py
@@ -102,6 +102,7 @@ class TestSetup():
               conflict_resolution_mode: ConflictResolution = ConflictResolution.AUTO,
               add_option_string_dash_variants: bool = False,
               parse_known_args: bool=False,
+              attempt_to_reorder: bool=False,
               ) -> Dataclass:
         """Basic setup for a test.
 
@@ -123,13 +124,13 @@ class TestSetup():
 
         if arguments is None:
             if parse_known_args:
-                args = parser.parse_known_args()
+                args = parser.parse_known_args(attempt_to_reorder=attempt_to_reorder)
             else:
                 args = parser.parse_args()
         else:
             splits = shlex.split(arguments)
             if parse_known_args:
-                args = parser.parse_known_args(splits)
+                args, unknown_args = parser.parse_known_args(splits, attempt_to_reorder=attempt_to_reorder)
             else:
                 args = parser.parse_args(splits)
         assert hasattr(


### PR DESCRIPTION
Turned off the 'experimental' subparser arg re-ordering, which I accidentally
published previously. This therefore adds a attempt_to_reorder argument to
ArgumentParser.parse_known_args, which will control if we attempt to reorder
the arguments.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>