### PR TITLE
Fix OrderedDict Serialization

### DIFF
--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -269,6 +269,10 @@ def decode_dict(K_: Type[K], V_: Type[V]) -> Callable[[List[Tuple[Any, Any]]], D
         if isinstance(val, list):
             result = OrderedDict()
             items = val
+        elif isinstance(val, OrderedDict):
+            # NOTE(ycho): Needed to propagate `OrderedDict` type
+            result = OrderedDict()
+            items = val.items()
         else:
             items = val.items()
         for k, v in items:

--- a/simple_parsing/helpers/serialization/serializable.py
+++ b/simple_parsing/helpers/serialization/serializable.py
@@ -25,11 +25,13 @@ D = TypeVar("D", bound="Serializable")
 try:
     import yaml
     def ordered_dict_constructor(loader: yaml.Loader, node: yaml.Node):
-        value = loader.construct_sequence(node)
+        # NOTE(ycho): `deep` has to be true for `construct_yaml_seq`.
+        value = loader.construct_sequence(node, deep = True)
         return OrderedDict(*value)
 
     def ordered_dict_representer(dumper: yaml.Dumper, instance: OrderedDict) -> yaml.Node:
-        node = dumper.represent_sequence("OrderedDict", instance.items())
+        # NOTE(ycho): nested list for compatibility with PyYAML's representer
+        node = dumper.represent_sequence("OrderedDict", [list(instance.items())])
         return node
 
     yaml.add_representer(OrderedDict, ordered_dict_representer)


### PR DESCRIPTION
Hi! This is Yoonyoung (Jamie) Cho. First of all, thank you for this amazing library!
I have recently been using `SimpleParsing` quite often on quick CLI applications, and the experience has been very pleasant.
In one of the use cases, I found a minor bug with `simple-parsing` with regards to serialization of `collections.OrderedDict`.

# Problem

Specifically, the error log looks like the following:

```bash
# ...
hyperparams = yaml.load(f, Loader=yaml.UnsafeLoader)  # pytype: disable=module-attr
  File "/home/jamiecho/.local/lib/python3.6/site-packages/yaml/__init__.py", line 114, in load
    return loader.get_single_data()
  File "/home/jamiecho/.local/lib/python3.6/site-packages/yaml/constructor.py", line 51, in get_single_data
    return self.construct_document(node)
  File "/home/jamiecho/.local/lib/python3.6/site-packages/yaml/constructor.py", line 55, in construct_document
    data = self.construct_object(node)
  File "/home/jamiecho/.local/lib/python3.6/site-packages/yaml/constructor.py", line 100, in construct_object
    data = constructor(self, node)
  File "/home/jamiecho/.local/lib/python3.6/site-packages/simple_parsing/helpers/serialization/serializable.py", line 30, in ordered_dict_constructor
    out =  OrderedDict(*value)
TypeError: expected at most 1 arguments, got 12
```
In this example, importing `simple_parsing` caused a side effect where a simple yaml loading from another part of code broke down.

## Minimal Reproducible Example

After digging into the matter a bit, I realized that this error was coming from the mismatch between the constructor and the representer. The following script is a minimal example that can reproduce the error. I have tested it with `python 3.7.5` and `python 3.6.9` (with `dataclasses` backport).
```python
#!/usr/bin/env python3

import sys
from collections import OrderedDict
import yaml
from typing import List
import logging
import multiprocessing as mp
import tempfile


def yaml_dump_load() -> bool:
    """ Dump and load a sample `OrderedDict`, returns True if succeeded"""
    data = OrderedDict([('a', 1), ('c', 3), ('b', 2)])
    with tempfile.TemporaryFile(mode='w+') as f:
        # write
        yaml.dump(data, f)
        # read
        f.seek(0)
        # `UnsafeLoader` only needed for without_sp, but on by default for simplicity
        data2 = yaml.load(f, Loader=yaml.UnsafeLoader)
    logging.info('{} == {}'.format(data, data2))
    return (data == data2)


def with_sp(_) -> bool:
    """ Run yaml_dump_load() with importing simple_parsing, returns True if succeeded """
    logging.basicConfig(level=logging.INFO)
    logging.info("With simple_parsing")
    try:
        import simple_parsing
        return yaml_dump_load()
    except TypeError as e:
        logging.error('with_sp failed : {}'.format(e))
        return False
    return True


def without_sp(_) -> bool:
    """ Run yaml_dump_load() without importing simple_parsing, returns True if succeeded """
    logging.basicConfig(level=logging.INFO)
    logging.info("Without simple_parsing")
    try:
        return yaml_dump_load()
    except TypeError as e:
        logging.error('without_sp failed : {}'.format(e))
        return False
    return True


def serializable_with_sp(_) -> bool:
    """ Serializable() load/save example, returns True if succeeded. """
    logging.basicConfig(level=logging.INFO)
    logging.info("Example with Serializable")
    from dataclasses import dataclass
    from simple_parsing import Serializable

    @dataclass
    class Data(Serializable):
        member: OrderedDict

    data = Data(OrderedDict([('a', 1), ('b', 2), ('d', 5), ('c', 4)]))

    try:
        with tempfile.NamedTemporaryFile(mode='w+', suffix='.yaml') as f:
            data.save(f.name)
            f.seek(0)
            data2 = Data.load(f.name)
    except TypeError as e:
        logging.error('serializable_with_sp failed : {}'.format(e))
        return False
    logging.info('{} == {}'.format(data, data2))
    return (data == data2) and type(data.member) == type(data2.member)


def test_with_sp():
    ctx = mp.get_context(method='spawn')
    with ctx.Pool(1) as p:
        assert(p.map(with_sp, [None])[0])


def test_without_sp():
    ctx = mp.get_context(method='spawn')
    with ctx.Pool(1) as p:
        assert(p.map(without_sp, [None])[0])


def test_serializable():
    ctx = mp.get_context(method='spawn')
    with ctx.Pool(1) as p:
        assert(p.map(serializable_with_sp, [None])[0])


def main():
    # Typically, pytest <test_serialize_ordered_dict.py> would work.
    # Just in case, also allow running the script directly.
    logging.basicConfig(level=logging.INFO)
    logging.info('Python version = {}'.format(sys.version))

    test_with_sp()
    test_without_sp()
    test_serializable()

    logging.info('Succesfully passed all assertions!')


if __name__ == '__main__':
    main()
```
Apologies in advance if the above script isn't as clean as it could have been ... but hopefully it gets the point across.
The expected output is something like the following:
```
$ pytest serialize_ordered_dict.py 
=========================================== test session starts ===========================================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /tmp
plugins: forked-1.3.0, xdist-2.2.0, cov-2.11.1, env-0.6.2
collected 3 items                                                                                         

serialize_ordered_dict.py ...                                                                       [100%]

============================================ 3 passed in 0.64s ============================================
```
However, in the current version, I get:
(`python3.6`)
```
$ pytest serialize_ordered_dict.py 
=========================================== test session starts ===========================================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /tmp
plugins: forked-1.3.0, xdist-2.2.0, cov-2.11.1, env-0.6.2
collected 3 items                                                                                         

serialize_ordered_dict.py F.F                                                                       [100%]

================================================ FAILURES =================================================
______________________________________________ test_with_sp _______________________________________________

    def test_with_sp():
        ctx = mp.get_context(method='spawn')
        with ctx.Pool(1) as p:
>           assert(p.map(with_sp, [None])[0])
E           assert False

serialize_ordered_dict.py:78: AssertionError
------------------------------------------ Captured stderr call -------------------------------------------
INFO:root:With simple_parsing
ERROR:root:with_sp failed : expected at most 1 arguments, got 3
____________________________________________ test_serializable ____________________________________________

    def test_serializable():
        ctx = mp.get_context(method='spawn')
        with ctx.Pool(1) as p:
>           assert(p.map(serializable_with_sp, [None])[0])
E           assert False

serialize_ordered_dict.py:90: AssertionError
------------------------------------------ Captured stderr call -------------------------------------------
INFO:root:Example with Serializable
ERROR:root:serializable_with_sp failed : expected at most 1 arguments, got 4
========================================= short test summary info =========================================
FAILED serialize_ordered_dict.py::test_with_sp - assert False
FAILED serialize_ordered_dict.py::test_serializable - assert False
```

(`python3.7`)
```
$ pytest serialize_ordered_dict.py 
=========================================== test session starts ===========================================
platform linux -- Python 3.7.5, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /tmp
collected 3 items                                                                                         

serialize_ordered_dict.py F.F                                                                       [100%]

================================================ FAILURES =================================================
______________________________________________ test_with_sp _______________________________________________

    def test_with_sp():
        ctx = mp.get_context(method='spawn')
        with ctx.Pool(1) as p:
>           assert(p.map(with_sp, [None])[0])
E           assert False

serialize_ordered_dict.py:78: AssertionError
------------------------------------------ Captured stderr call -------------------------------------------
INFO:root:With simple_parsing
INFO:root:OrderedDict([('a', 1), ('c', 3), ('b', 2)]) == OrderedDict()
____________________________________________ test_serializable ____________________________________________

    def test_serializable():
        ctx = mp.get_context(method='spawn')
        with ctx.Pool(1) as p:
>           assert(p.map(serializable_with_sp, [None])[0])
E           assert False

serialize_ordered_dict.py:90: AssertionError
------------------------------------------ Captured stderr call -------------------------------------------
INFO:root:Example with Serializable
INFO:root:serializable_with_sp.<locals>.Data(member=OrderedDict([('a', 1), ('b', 2), ('d', 5), ('c', 4)])) == serializable_with_sp.<locals>.Data(member={})
========================================= short test summary info =========================================
FAILED serialize_ordered_dict.py::test_with_sp - assert False
FAILED serialize_ordered_dict.py::test_serializable - assert False
======================================= 2 failed, 1 passed in 0.47s =======================================
```

They fail in slightly different ways, but the point is that neither can produce the expected output.
Specifically, in the current version, some of the failure modes are as follows:
* Failure to reconstruct value (e.g. `expected at most 1 arguments, got 3`)
* While loading, object decodes into empty dict (e.g. `loader.construct_sequence(node) == {}`)
* `OrderedDict` becomes `dict` (e.g. `Data(member={...}` instead of `Data(member=OrderedDict[...]`))

Since merely importing `simple_parsing` can result in such side effects, I think it's desirable to fix this issue.
Fortunately, the fix is relatively straightforward and it's (hopefully) easy to recognize which lines address which issue.

## Solution

The fix is just a change in three lines: `constructor`/`representer` pairs should be compatible, and since the constructor is reused both should match the defaults from `PyYAML`. The constructor should enable deep construction for the underlying sequence, as well as preserve the `OrderedDict` type in the reconstructed output when decoding so that the type doesn't decay to `dict`.

Hopefully this is useful!