### PR TITLE
Support serialization for tuples with ellipsis

### DIFF
--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -218,18 +218,28 @@ def decode_tuple(*tuple_item_types: Type[T]) -> Callable[[List[T]], Tuple[T, ...
         Callable[[List[T]], Tuple[T, ...]]: A parsing function for creating tuples.
     """
     # Get the decoding function for each item type
-    decoding_fns = [
-        get_decoding_fn(t) for t in tuple_item_types
-    ]
+    has_ellipsis = False
+    if Ellipsis in tuple_item_types:
+        ellipsis_index = tuple_item_types.index(Ellipsis)
+        decoding_fn_index = ellipsis_index - 1
+        decoding_fn = get_decoding_fn(tuple_item_types[decoding_fn_index])
+        has_ellipsis = True
+    else:
+        decoding_fns = [
+            get_decoding_fn(t) for t in tuple_item_types
+        ]
     # Note, if there are more values than types in the tuple type, then the
     # last type is used.
-    # TODO: support the Ellipsis?
-
     def _decode_tuple(val: Tuple[Any, ...]) -> Tuple[T, ...]:
         result: List[T] = []
-        return tuple(
-            decoding_fns[i](v) for i, v in enumerate(val)
-        )
+        if has_ellipsis:
+            return tuple(
+                decoding_fn(v) for v in val
+            )
+        else:
+            return tuple(
+                decoding_fns[i](v) for i, v in enumerate(val)
+            )
     return _decode_tuple
 
 

--- a/test/utils/test_serialization.py
+++ b/test/utils/test_serialization.py
@@ -363,6 +363,15 @@ for Serializable in (Serializable, YamlSerializable):
         g_ = Leaderboard.loads(s)
         assert isinstance(g_.participants, dict)
 
+    def test_tuple_with_ellipsis():
+
+        @dataclass
+        class Container(Serializable):
+            ints: Tuple[int, ...] = ()
+
+        container = Container(ints = (1,2))
+        assert Container.loads(container.dumps()) == container
+
 
 def test_choice_dict_with_nonserializable_values():
     """ Test that when a choice_dict has values of some non-json-serializable type, a


### PR DESCRIPTION
Hi again! This is Yoonyoung (Jamie) Cho.

I've been using `SimpleParsing` quite a lot recently, and I've come across a use case for serialization for variable-length homogeneous tuples. There was a `TODO` (`# TODO: support the Ellipsis?`) and I needed this capability, so I figured I should create a PR for this feature. Hopefully this is useful.

## Description
Currently, `decode_tuple()` cannot handle cases such as `Tuple[int,...]`. There's a check in `parse_tuple()` that deals with ellipses, but similar fix was not adopted for serialization (decoding such tuples) - I tried to follow the same style as the existing function, which looks to be more robust than simply checking for `tuple_item_types[0]`, although I agree with the comments that in general the only allowable form of such tuples is `Tuple[T, ...]` (other uses of ellipses would result in a `TypeError` such as `Tuple[t0, t1, ...]: each t must be a type. Got Ellipsis.`).

I also added a test in `utils/test_serialization.py` for simply checking the equivalence of the dataclass instance after saving to and loading from the serialized string.

## Pytest
```
$ pytest utils/test_serialization.py
=========================================== test session starts ===========================================
platform linux -- Python 3.6.9, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /home/jamiecho/Repos/Ravel/SimpleParsing
plugins: forked-1.3.0, xdist-2.2.0, cov-2.11.1, env-0.6.2
collected 19 items                                                                                        

utils/test_serialization.py ...................                                                     [100%]

=========================================== 19 passed in 0.08s ============================================
```

Hopefully this is useful!