### PR TITLE
support dynamically created nested dataclass

### DIFF
--- a/simple_parsing/docstring.py
+++ b/simple_parsing/docstring.py
@@ -39,7 +39,7 @@ def get_attribute_docstring(
     """
     try:
         source = inspect.getsource(some_dataclass)
-    except TypeError as e:
+    except (TypeError, OSError) as e:
         logger.debug(f"Couldn't find the attribute docstring: {e}")
         return AttributeDocString()
 


### PR DESCRIPTION
## Description
I am trying to use SimpleParsing with dynamically created dataclass that has another dynamically created dataclass as field.

I fixed the code to circumvent this error.

## Code
The following code does not work:
```python
from dataclasses import make_dataclass, field
from simple_parsing import ArgumentParser

Nested = make_dataclass(f"Nested", [('a', int, field(default=1))])
Config = make_dataclass(f"Config", [('nested', Nested, field())])
parser = ArgumentParser(add_option_string_dash_variants=True)
parser.add_arguments(Config, dest="config")
args = parser.parse_args()
```

Result:
```
Traceback (most recent call last):
  File "script.py", line 8, in <module>
    args = parser.parse_args()
  File "xxx/lib/python3.8/argparse.py", line 1768, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "xxx/lib/python3.8/site-packages/simple_parsing/parsing.py", line 162, in parse_known_args
    self._preprocessing()
  File "xxx/lib/python3.8/site-packages/simple_parsing/parsing.py", line 221, in _preprocessing
    wrapper.add_arguments(parser=self)
  File "xxx/lib/python3.8/site-packages/simple_parsing/wrappers/dataclass_wrapper.py", line 90, in add_arguments
    group = parser.add_argument_group(title=self.title, description=self.description)
  File "xxx/lib/python3.8/site-packages/simple_parsing/wrappers/dataclass_wrapper.py", line 178, in description
    doc = docstring.get_attribute_docstring(self.parent.dataclass, self._field.name)            
  File "xxx/lib/python3.8/site-packages/simple_parsing/docstring.py", line 39, in get_attribute_docstring
    source = inspect.getsource(some_dataclass)
  File "xxx/lib/python3.8/inspect.py", line 985, in getsource
    lines, lnum = getsourcelines(object)
  File "xxx/lib/python3.8/inspect.py", line 967, in getsourcelines
    lines, lnum = findsource(object)
  File "xxx/lib/python3.8/inspect.py", line 824, in findsource
    raise OSError('could not find class definition')
OSError: could not find class definition

```

This problem is fixed by this PR.