### PR TITLE
Changes to allow Extensibility

### DIFF
--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -94,11 +94,17 @@ class ArgumentParser(argparse.ArgumentParser):
         dest: str,
         prefix: str = "",
         default: Dataclass = None,
+        dataclass_wrapper_class: Type[DataclassWrapper] = DataclassWrapper,
     ):
         pass
 
     @overload
-    def add_arguments(self, dataclass: Dataclass, dest: str, prefix: str = ""):
+    def add_arguments(self,
+        dataclass: Dataclass,
+        dest: str,
+        prefix: str = "",
+        dataclass_wrapper_class: Type[DataclassWrapper] = DataclassWrapper,
+    ):
         pass
 
     def add_arguments(
@@ -107,6 +113,7 @@ class ArgumentParser(argparse.ArgumentParser):
         dest: str,
         prefix: str = "",
         default: Union[Dataclass, Dict] = None,
+        dataclass_wrapper_class: Type[DataclassWrapper] = DataclassWrapper,
     ):
         """Adds command-line arguments for the fields of `dataclass`.
 
@@ -140,7 +147,7 @@ class ArgumentParser(argparse.ArgumentParser):
             default = dataclass if default is None else default
             dataclass = type(dataclass)
 
-        new_wrapper = DataclassWrapper(dataclass, dest, prefix=prefix, default=default)
+        new_wrapper = dataclass_wrapper_class(dataclass, dest, prefix=prefix, default=default)
         self._wrappers.append(new_wrapper)
 
     def parse_known_args(

--- a/simple_parsing/wrappers/dataclass_wrapper.py
+++ b/simple_parsing/wrappers/dataclass_wrapper.py
@@ -21,6 +21,7 @@ class DataclassWrapper(Wrapper[Dataclass]):
         prefix: str = "",
         parent: "DataclassWrapper" = None,
         _field: dataclasses.Field = None,
+        field_wrapper_class: Type[FieldWrapper] = FieldWrapper
     ):
         # super().__init__(dataclass, name)
         self.dataclass = dataclass
@@ -51,7 +52,7 @@ class DataclassWrapper(Wrapper[Dataclass]):
                 continue
 
             if utils.is_subparser_field(field) or utils.is_choice(field):
-                wrapper = FieldWrapper(field, parent=self, prefix=prefix)
+                wrapper = field_wrapper_class(field, parent=self, prefix=prefix)
                 self.fields.append(wrapper)
 
             elif utils.is_tuple_or_list_of_dataclasses(field.type):
@@ -80,7 +81,7 @@ class DataclassWrapper(Wrapper[Dataclass]):
 
             else:
                 # a normal attribute
-                field_wrapper = FieldWrapper(field, parent=self, prefix=self.prefix)
+                field_wrapper = field_wrapper_class(field, parent=self, prefix=self.prefix)
                 logger.debug(
                     f"wrapped field at {field_wrapper.dest} has a default value of {field_wrapper.default}"
                 )


### PR DESCRIPTION
For example, I use these hooks to do the help doc that I prefer:

```
class DataclassWrapper(DataclassWrapper_):
    @property
    def title(self) -> str:
        return self.dataclass.__qualname__

    @property
    def description(self) -> str:
        # TODO Don't show dataclass default __doc__
        return self.dataclass.__doc__ or ""
```