### PR TITLE
Add Optional Subparsers

### DIFF
--- a/examples/subparsers/optional_subparsers.py
+++ b/examples/subparsers/optional_subparsers.py
@@ -1,0 +1,45 @@
+from typing import Union
+from simple_parsing.helpers.fields import subparsers
+from simple_parsing.helpers.hparams.hyperparameters import HyperParameters
+from dataclasses import dataclass
+
+from simple_parsing import ArgumentParser
+
+
+@dataclass
+class AConfig:
+    foo: int = 123
+
+
+@dataclass
+class BConfig:
+    bar: float = 4.56
+
+
+@dataclass
+class Options:
+    config: Union[AConfig, BConfig] = subparsers({"a": AConfig, "b": BConfig}, default=AConfig())
+
+
+def main():
+    parser = ArgumentParser()
+
+    parser.add_arguments(Options, dest="options")
+
+    # Equivalent to:
+    # subparsers = parser.add_subparsers(title="config", required=False)
+    # parser.set_defaults(config=AConfig())
+    # a_parser = subparsers.add_parser("a", help="A help.")
+    # a_parser.add_arguments(AConfig, dest="config")
+    # b_parser = subparsers.add_parser("b", help="B help.")
+    # b_parser.add_arguments(BConfig, dest="config")
+
+    args = parser.parse_args()
+
+    print(args)
+    options: Options = args.options
+    print(options)
+
+
+if __name__ == "__main__":
+    main()

--- a/simple_parsing/helpers/fields.py
+++ b/simple_parsing/helpers/fields.py
@@ -344,11 +344,14 @@ def mutable_field(
 MutableField = mutable_field
 
 
-def subparsers(subcommands: Dict[str, Type[Dataclass]], **kwargs) -> Any:
+def subparsers(
+    subcommands: Dict[str, Type[Dataclass]], default: Dataclass = MISSING, **kwargs
+) -> Any:
     return field(
         metadata={
             "subparsers": subcommands,
         },
+        default=default,
         **kwargs,
     )
 

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -856,13 +856,21 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
         from simple_parsing import ArgumentParser  # Just for typing.
 
         # add subparsers for each dataclass type in the field.
+        default_value = self.field.default
+        if default_value is dataclasses.MISSING:
+            if self.field.default_factory is not dataclasses.MISSING:
+                default_value = self.field.default_factory()
+
         subparsers = parser.add_subparsers(
             title=self.name,
             description=self.help,
             dest=self.dest,
             parser_class=ArgumentParser,
+            required=(default_value is dataclasses.MISSING),
         )
-        subparsers.required = True
+        if default_value is not dataclasses.MISSING:
+            parser.set_defaults(**{self.dest: default_value})
+        # subparsers.required = default_value is dataclasses.MISSING
         for subcommand, dataclass_type in self.subparsers_dict.items():
             logger.debug(f"adding subparser '{subcommand}' for type {dataclass_type}")
             subparser = subparsers.add_parser(subcommand)

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -861,13 +861,22 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
             if self.field.default_factory is not dataclasses.MISSING:
                 default_value = self.field.default_factory()
 
-        subparsers = parser.add_subparsers(
+        add_subparser_kwargs = dict(
             title=self.name,
             description=self.help,
             dest=self.dest,
             parser_class=ArgumentParser,
             required=(default_value is dataclasses.MISSING),
         )
+        import sys
+
+        if sys.version_info[:2] == (3, 6):
+            required = add_subparser_kwargs.pop("required")
+            subparsers = parser.add_subparsers(**add_subparser_kwargs)
+            subparsers.required = required
+        else:
+            subparsers = parser.add_subparsers(**add_subparser_kwargs)
+
         if default_value is not dataclasses.MISSING:
             parser.set_defaults(**{self.dest: default_value})
         # subparsers.required = default_value is dataclasses.MISSING

--- a/test/test_optional_subparsers.py
+++ b/test/test_optional_subparsers.py
@@ -1,0 +1,104 @@
+from typing import Union
+from simple_parsing.helpers.fields import field, subparsers
+from simple_parsing.helpers.hparams.hyperparameters import HyperParameters
+from dataclasses import dataclass
+from .testutils import TestSetup
+import functools
+
+from simple_parsing import ArgumentParser
+
+
+@dataclass
+class A:
+    foo: int = 123
+
+
+@dataclass
+class B:
+    bar: float = 4.56
+
+
+class TestWithDefault:
+    @dataclass
+    class Options(TestSetup):
+        config: Union[A, B] = subparsers({"a": A, "b": B}, default=A(foo=0))
+
+    def test_default_is_used_when_no_args_passed(self):
+        assert self.Options.setup("").config == A(foo=0)
+
+    def test_subparsers_work(self):
+        assert self.Options.setup("a --foo 456").config == A(foo=456)
+        assert self.Options.setup("b --bar 1.23").config == B(bar=1.23)
+
+
+class TestWithDefaultFactory:
+    @dataclass
+    class Options(TestSetup):
+        config: Union[A, B] = subparsers(
+            {"a": A, "b": B}, default_factory=functools.partial(A, foo=0)
+        )
+
+    def test_default_is_used_when_no_args_passed(self):
+        assert self.Options.setup("").config == A(foo=0)
+
+    def test_subparsers_work(self):
+        assert self.Options.setup("a --foo 456").config == A(foo=456)
+        assert self.Options.setup("b --bar 1.23").config == B(bar=1.23)
+
+
+class TestWithoutSubparsersField:
+    @dataclass
+    class Options(TestSetup):
+        config: Union[A, B] = field(default_factory=functools.partial(A, foo=0))
+
+    def test_default_is_used_when_no_args_passed(self):
+        assert self.Options.setup("").config == A(foo=0)
+
+    def test_subparsers_work(self):
+        assert self.Options.setup("a --foo 456").config == A(foo=456)
+        assert self.Options.setup("b --bar 1.23").config == B(bar=1.23)
+
+
+class TestWithoutSubparsersField:
+    @dataclass
+    class Options(TestSetup):
+        config: Union[A, B] = field(
+            default=A(foo=0),
+        )
+
+    def test_default_is_used_when_no_args_passed(self):
+        assert self.Options.setup("").config == A(foo=0)
+
+    def test_subparsers_work(self):
+        assert self.Options.setup("a --foo 456").config == A(foo=456)
+        assert self.Options.setup("b --bar 1.23").config == B(bar=1.23)
+
+
+def test_nesting_of_optional_subparsers():
+    @dataclass
+    class Bob:
+        config: Union[A, B] = subparsers({"a": A, "b": B}, default=A(foo=0))
+
+    @dataclass
+    class Clarice:
+        config: Union[A, B] = subparsers({"a": A, "b": B}, default=A(foo=0))
+
+    @dataclass
+    class NestedOptions(TestSetup):
+        friend: Union[Bob, Clarice] = Bob()
+
+    assert NestedOptions.setup("") == NestedOptions()
+    assert NestedOptions.setup("bob") == NestedOptions(friend=Bob())
+    assert NestedOptions.setup("bob a") == NestedOptions(friend=Bob(config=A()))
+    assert NestedOptions.setup("bob a --foo 1") == NestedOptions(friend=Bob(config=A(foo=1)))
+    assert NestedOptions.setup("bob b") == NestedOptions(friend=Bob(config=B()))
+    assert NestedOptions.setup("bob b --bar 0.") == NestedOptions(friend=Bob(config=B(bar=0.0)))
+    assert NestedOptions.setup("clarice") == NestedOptions(friend=Clarice())
+    assert NestedOptions.setup("clarice a") == NestedOptions(friend=Clarice(config=A()))
+    assert NestedOptions.setup("clarice a --foo 1") == NestedOptions(
+        friend=Clarice(config=A(foo=1))
+    )
+    assert NestedOptions.setup("clarice b") == NestedOptions(friend=Clarice(config=B()))
+    assert NestedOptions.setup("clarice b --bar 0.") == NestedOptions(
+        friend=Clarice(config=B(bar=0.0))
+    )


### PR DESCRIPTION
Adds optional subparsers, by either passing a default or default_factory to the `subparsers` function, or by setting a default value on the field.