### PR TITLE
Fix bug with new Union syntax with postponed type annotations

### DIFF
--- a/simple_parsing/utils.py
+++ b/simple_parsing/utils.py
@@ -970,7 +970,7 @@ def _replace_new_union_syntax_with_old_union_syntax(annotations_dict: Dict[str, 
 
     def _get_type(ann: str) -> Union[type, str]: 
         # Try locals, then globals, then builtins. Otherwise, use the annotation itself.
-        return local_ns.get(ann, global_ns.get(ann, getattr(builtins, ann, ann)))
+        return forward_refs_to_types.get(ann, local_ns.get(ann, global_ns.get(ann, getattr(builtins, ann, ann))))
     
     def _not_supported() -> typing.NoReturn:
         raise NotImplementedError(f"Don't yet support annotations like these: {annotations_dict}")

--- a/simple_parsing/wrappers/dataclass_wrapper.py
+++ b/simple_parsing/wrappers/dataclass_wrapper.py
@@ -55,7 +55,7 @@ class DataclassWrapper(Wrapper[Dataclass]):
             if isinstance(field.type, str):
                 # NOTE: Here we'd like to convert the fields type to an actual type, in case the
                 # `from __future__ import annotations` feature is used.
-                field_type = utils.get_field_type_from_field_annotation(self.dataclass, field.name)
+                field_type = utils.get_field_type_from_annotations(self.dataclass, field.name)
                 # Modify the `type` of the Field object, in-place.
                 field.type = field_type
 

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -733,7 +733,7 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
                 # NOTE: Here we'd like to convert the fields type to an actual type, in case the
                 # `from __future__ import annotations` feature is used.
                 # This should also resolve most forward references.
-                field_type = utils.get_field_type_from_field_annotation(self.parent.dataclass, self.field.name)
+                field_type = utils.get_field_type_from_annotations(self.parent.dataclass, self.field.name)
                 self._type = field_type
 
             if self.is_choice and self.choice_dict:

--- a/test/test_future_annotations.py
+++ b/test/test_future_annotations.py
@@ -1,5 +1,6 @@
 """ Tests for compatibility with the postponed evaluation of annotations. """
 from __future__ import annotations
+import dataclasses
 
 from simple_parsing import ArgumentParser
 import sys
@@ -14,10 +15,10 @@ from .testutils import TestSetup
 @dataclass
 class Foo(TestSetup):
     a: int = 123
-    
+
     b: str = "fooobar"
     c: tuple[int, float] = (123, 4.56)
-    
+
     d: list[bool] = field(default_factory=list)
 
 
@@ -29,7 +30,9 @@ class Bar(TestSetup):
     some_list: list[float] = field(default_factory=[1.0, 2.0].copy)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="Needs access to annotations from __future__")
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Needs access to annotations from __future__"
+)
 def test_future_annotations():
     foo = Foo.setup()
     assert foo == Foo()
@@ -38,7 +41,9 @@ def test_future_annotations():
     assert foo == Foo(a=2, b="heyo", c=(1, 7.89))
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="Needs access to annotations from __future__")
+@pytest.mark.skipif(
+    sys.version_info < (3, 7), reason="Needs access to annotations from __future__"
+)
 def test_future_annotations_nested():
     bar = Bar.setup()
     assert bar == Bar()
@@ -46,4 +51,21 @@ def test_future_annotations_nested():
     bar = Bar.setup("--barry.a 2 --barry.b heyo --barry.c 1 7.89")
     assert bar.barry == Foo(a=2, b="heyo", c=(1, 7.89))
     assert isinstance(bar.joe, Foo)
-    
+
+
+@dataclass
+class ClassWithNewUnionSyntax(TestSetup):
+    v: int | float = 123
+
+
+def test_new_union_syntax():
+    assert ClassWithNewUnionSyntax.setup() == ClassWithNewUnionSyntax()
+    assert ClassWithNewUnionSyntax.setup("--v 456") == ClassWithNewUnionSyntax(v=456)
+    assert ClassWithNewUnionSyntax.setup("--v 4.56") == ClassWithNewUnionSyntax(v=4.56)
+    from simple_parsing.utils import is_union
+
+    type_annotation = dataclasses.fields(ClassWithNewUnionSyntax)[0].type
+    assert is_union(type_annotation)
+
+    # with pytest.raises(Exception):
+    #     assert ClassWithNewUnionSyntax.setup("--v bob")

--- a/test/test_union.py
+++ b/test/test_union.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
-from .testutils import *
+
+from simple_parsing.parsing import ParsingError
+from .testutils import TestSetup, exits_and_writes_to_stderr, raises
 from typing import Union
 
 
@@ -15,4 +17,19 @@ def test_union_type():
     assert foo.x == "bob"
 
     foo = Foo.setup("--x 2")
+    assert foo.x == 2 and type(foo.x) is int
+
+
+def test_union_type_raises_error():
+    @dataclass
+    class Foo2(TestSetup):
+        x: Union[int, float] = 0
+
+    foo = Foo2.setup("--x 1.2")
+    assert foo.x == 1.2
+
+    with exits_and_writes_to_stderr(match="invalid int|float value: 'bob'"):
+        foo = Foo2.setup("--x bob")
+
+    foo = Foo2.setup("--x 2")
     assert foo.x == 2 and type(foo.x) is int


### PR DESCRIPTION
This is a 'hotfix' to add a feature missing from the last release: support for annotations of this kind:
```python
from __future__ import annotations
from dataclasses import dataclass, field

@dataclass
class Foo:
    a: int | bool = False
    c: list[int] | list[float] = field(default_factory=list)
```
However, beware, the second one (union of containers, as well as containers of unions) aren't yet properly supported!
The current way to get this to work is to:
```python
def _int_or_float(v: str) -> int | float:
    try:
        return int(v)
    return float(v)

@dataclass
class Foo:
    a: int | bool = False
    c: list[int] | list[float] = field(default_factory=list, type=_int_or_float)
```

This makes argparse use the given type for the argument.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>