### PR TITLE
Fix parsing defaults for nested dataclasses

### DIFF
--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -99,7 +99,8 @@ class ArgumentParser(argparse.ArgumentParser):
         pass
 
     @overload
-    def add_arguments(self,
+    def add_arguments(
+        self,
         dataclass: Dataclass,
         dest: str,
         prefix: str = "",

--- a/simple_parsing/wrappers/dataclass_wrapper.py
+++ b/simple_parsing/wrappers/dataclass_wrapper.py
@@ -80,8 +80,12 @@ class DataclassWrapper(Wrapper[Dataclass]):
             elif utils.contains_dataclass_type_arg(field.type):
                 dataclass = utils.get_dataclass_type_arg(field.type)
                 name = field.name
+
                 child_wrapper = DataclassWrapper(
-                    dataclass, name, parent=self, _field=field, default=None
+                    dataclass, name, parent=self, _field=field,
+                    # Fields from default values should propagate
+                    # down to children classes, if they are provided
+                    default=getattr(default, name) if hasattr(default, name) else None
                 )
                 child_wrapper.required = False
                 child_wrapper.optional = True


### PR DESCRIPTION
When parsing a dataclass that has other dataclass fields in turn, and a default dataclass instance is provided, the parser in its current form ignores values for children dataclasses if they are default, even if the given configuration explicitly provides those values.

For instance,

```python

@dataclass
class A:
  p: int
  q: float

@dataclass
class B:
  x: int
  y: Optional[A] = None
```

For this configuration, a dataclass corresponding to the following configuratiton:
```python
{'B': 'x': 3, 'y': {p: 4, q: 0.1}}
```
when parsed by the module, will result in
```python
{'B': x}
```