### PR TITLE
Fix #126, deserialization with postponed type ants

### DIFF
--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -1,11 +1,13 @@
 """ Functions for decoding dataclass fields from "raw" values (e.g. from json).
 """
+import inspect
 import warnings
 from collections import OrderedDict
 from dataclasses import Field, fields
 from functools import lru_cache, partial
 from logging import getLogger
 from typing import TypeVar, Any, Dict, Type, Callable, Optional, Union, List, Tuple, Set
+
 
 from simple_parsing.utils import (
     get_type_arguments,
@@ -93,6 +95,35 @@ def get_decoding_fn(t: Type[T]) -> Callable[[Any], T]:
     """
     # cache_info = get_decoding_fn.cache_info()
     # logger.debug(f"called for type {t}! Cache info: {cache_info}")
+
+    if isinstance(t, str):
+        # Type annotation is a string.
+        # This can happen when the `from __future__ import annotations` feature is used.
+        potential_keys: List[Type] = []
+        for key in _decoding_fns:
+            if inspect.isclass(key):
+                if key.__qualname__ == t:
+                    # Qualname is more specific, there can't possibly be another match, so break.
+                    potential_keys.append(key)
+                    break
+                if key.__qualname__ == t:
+                    # For just __name__, there could be more than one match.
+                    potential_keys.append(key)
+
+        if not potential_keys:
+            raise ValueError(
+                f"Couldn't find a decoding function for the string annotation '{t}'.\n"
+                f"This is probably a bug. If it is, please make an issue on GitHub so we can get "
+                f"to work on fixing it."
+            )
+        if len(potential_keys) == 1:
+            t = potential_keys[0]
+        else:
+            raise ValueError(
+                f"Multiple decoding functions registered for a type {t}: {potential_keys} \n"
+                f"This could be a bug, but try to use different names for each type, or add the "
+                f"modules they come from as a prefix, perhaps?"
+            )
 
     if t in _decoding_fns:
         # The type has a dedicated decoding function.

--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -206,8 +206,9 @@ def get_decoding_fn(t: Type[T]) -> Callable[[Any], T]:
     # Unknown type.
     warnings.warn(
         UserWarning(
-            f"Unable to find a decoding function for type {t}. "
-            f"Will try to use the type as a constructor."
+            f"Unable to find a decoding function for the annotation {t} (of type {type(t)}). "
+            f"Will try to use the type as a constructor. Consider registering a decoding function "
+            f"using `register_decoding_fn`, or posting an issue on GitHub. "
         )
     )
     return try_constructor(t)

--- a/test/test_future_annotations.py
+++ b/test/test_future_annotations.py
@@ -194,12 +194,39 @@ def test_parsing_containers_of_unions():
         vals_tuple: tuple[int | float, bool] = field(default=(1, False))
 
     assert MoreComplex.setup("--vals_list 456 123") == MoreComplex(vals_list=[456, 123])
-    assert MoreComplex.setup("--vals_list 4.56 1.23") == MoreComplex(
-        vals_list=[4.56, 1.23]
-    )
-    assert MoreComplex.setup("--vals_tuple 456 False") == MoreComplex(
-        vals_tuple=(456, False)
-    )
-    assert MoreComplex.setup("--vals_tuple 4.56 True") == MoreComplex(
-        vals_tuple=(4.56, True)
-    )
+    assert MoreComplex.setup("--vals_list 4.56 1.23") == MoreComplex(vals_list=[4.56, 1.23])
+    assert MoreComplex.setup("--vals_tuple 456 False") == MoreComplex(vals_tuple=(456, False))
+    assert MoreComplex.setup("--vals_tuple 4.56 True") == MoreComplex(vals_tuple=(4.56, True))
+
+
+from dataclasses import dataclass
+from simple_parsing.helpers import Serializable
+
+
+@dataclass
+class Opts1(Serializable):
+    a: int = 64
+    b: float = 1.0
+
+
+@dataclass
+class Opts2(Serializable):
+    a: int = 32
+    b: float = 0.0
+
+
+@dataclass
+class Wrapper(Serializable):
+    opts1: Opts1 = Opts1()
+    opts2: Opts2 = Opts2()
+
+
+def test_serialization_deserialization():
+    # Show that it's not possible to deserialize nested dataclasses
+    opts = Wrapper()
+    assert Wrapper in Serializable.subclasses
+    assert Opts1 in Serializable.subclasses
+    assert Opts2 in Serializable.subclasses
+    assert Wrapper.from_dict(opts.to_dict()) == opts
+    assert Wrapper.loads_json(opts.dumps_json()) == opts
+    assert Wrapper.loads_yaml(opts.dumps_yaml()) == opts


### PR DESCRIPTION
When `from __future__ import annotations` feature is used, the `Serializable.from_dict` method doesn't work correctly, since it can't find the right decoding function.

This fixes this bug, by checking if any known types match the given string, and then using those.

Also adds a test to reproduce issue #126 

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>