### PR TITLE
Include requirements.txt

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include simple_parsing/_version.py
+include requirements.txt


### PR DESCRIPTION
Currently requirements.txt is not included in the sdist, which causes setup.py to fail during building downstream in conda forge