### PR TITLE
Add better support for setting defaults from Config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Options ['options']:
     It's easy to choose between different argument groups of arguments, with the `subgroups`
     function!
 
+- ### [Setting defaults from Configuration files](https://github.com/lebrice/SimpleParsing/tree/master/examples/config_files/README.md)
+
+    Default values for command-line arguments can easily be read from many different formats, including json/yaml!
+
 - ### [**Easy serialization**](https://github.com/lebrice/SimpleParsing/tree/master/examples/serialization/README.md):
 
     Easily save/load configs to `json` or `yaml`!.

--- a/examples/config_files/README.md
+++ b/examples/config_files/README.md
@@ -1,0 +1,25 @@
+# Using config files
+
+Simple-Parsing can use default values from a configuration file.
+
+The `config_path` argument can be passed to the ArgumentParser constructor. The default values for
+all arguments will be set from that file.
+
+Additionally, when the `add_config_path_arg` argument of the `ArgumentParser` constructor is set,
+a `--config_path` argument will be added. This argument will overwrite the defaults.
+If the `config_path` argument to the `ArgumentParser` constructor is also set, then the values in
+the config file passed as `--config_path` are applied on top of those from the `ArgumentParser.config_file`.
+
+Therefore, the default values are set like so, in increasing priority:
+1. normal defaults (e.g. from the dataclass definitions)
+2. from the `config_path` argument of `ArgumentParser.__init__`
+3. from the `--config_path` argument on the command-line.
+
+
+## Examples:
+
+1. [train_model.py]()
+
+
+
+Note: Pyrallis is a "fork" of Simple-Parsing. It has some nice features. Check it out if you want.

--- a/examples/config_files/README.md
+++ b/examples/config_files/README.md
@@ -1,25 +1,32 @@
 # Using config files
 
-Simple-Parsing can use default values from a configuration file.
+Simple-Parsing can use default values from one or more configuration files.
 
-The `config_path` argument can be passed to the ArgumentParser constructor. The default values for
-all arguments will be set from that file.
+The `config_path` argument can be passed to the ArgumentParser constructor. The values read from
+that file will overwrite the default values from the dataclass definitions.
 
 Additionally, when the `add_config_path_arg` argument of the `ArgumentParser` constructor is set,
-a `--config_path` argument will be added. This argument will overwrite the defaults.
-If the `config_path` argument to the `ArgumentParser` constructor is also set, then the values in
-the config file passed as `--config_path` are applied on top of those from the `ArgumentParser.config_file`.
+a `--config_path` argument will be added to the parser. This argument accepts one or more paths to configuration
+files, whose contents will be read, and used to update the defaults, in the same manner as with the
+`config_path` argument above.
 
-Therefore, the default values are set like so, in increasing priority:
+When using both options (the `config_path` parameter of `ArgumentParser.__init__`, as well as the `--config_path` command-line argument), the defaults are first updated using `ArgumentParser.config_path`, and then
+updated with the contents of the `--config_path` file(s).
+
+In other words, the default values are set like so, in increasing priority:
 1. normal defaults (e.g. from the dataclass definitions)
-2. from the `config_path` argument of `ArgumentParser.__init__`
-3. from the `--config_path` argument on the command-line.
+2. updated with the contents of the `config_path` file(s) of `ArgumentParser.__init__`
+3. updated with the contents of the `--config_path` file(s) from the command-line.
 
 
-## Examples:
+## [Single Config example](one_config.py)
 
-1. [train_model.py]()
+When using a single config dataclass, the `simple_parsing.parse` function can then be used to simplify the argument parsing setup a bit.
 
+## [Multiple Configs](many_configs.py)
 
+Config files can also be used when defining multiple config dataclasses with the same parser.
 
-Note: Pyrallis is a "fork" of Simple-Parsing. It has some nice features. Check it out if you want.
+## [Composition](composition.py)
+
+Multiple config files can be composed together à-la Hydra!

--- a/examples/config_files/composition.py
+++ b/examples/config_files/composition.py
@@ -1,0 +1,65 @@
+""" Example where we compose different configurations! """
+
+import shlex
+from dataclasses import dataclass
+
+import simple_parsing
+
+
+@dataclass
+class Foo:
+    a: str = "default value for `a` (from the dataclass definition of Foo)"
+
+
+@dataclass
+class Bar:
+    b: str = "default value for `b` (from the dataclass definition of Bar)"
+
+
+@dataclass
+class Baz:
+    c: str = "default value for `c` (from the dataclass definition of Baz)"
+
+
+def main(args=None) -> None:
+    """Example using composition of different configurations."""
+    parser = simple_parsing.ArgumentParser(
+        add_config_path_arg=True, config_path="composition_defaults.yaml"
+    )
+
+    parser.add_arguments(Foo, dest="foo")
+    parser.add_arguments(Bar, dest="bar")
+    parser.add_arguments(Baz, dest="baz")
+
+    if isinstance(args, str):
+        args = shlex.split(args)
+    args = parser.parse_args(args)
+
+    foo: Foo = args.foo
+    bar: Bar = args.bar
+    baz: Baz = args.baz
+    print(f"foo: {foo}")
+    print(f"bar: {bar}")
+    print(f"baz: {baz}")
+
+
+main()
+expected = """
+foo: Foo(a="default value for `a` from the Parser's `config_path` (composition_defaults.yaml)")
+bar: Bar(b="default value for `b` from the Parser's `config_path` (composition_defaults.yaml)")
+baz: Baz(c="default value for `c` from the Parser's `config_path` (composition_defaults.yaml)")
+"""
+
+main("--a 'Value passed from the command-line.' --config_path config_b.yaml")
+expected += """\
+foo: Foo(a='Value passed from the command-line.')
+bar: Bar(b='default value for `b` from the config_b.yaml file')
+baz: Baz(c="default value for `c` from the Parser's `config_path` (composition_defaults.yaml)")
+"""
+
+main("--a 'Value passed from the command-line.' --config_path config_a.yaml config_b.yaml")
+expected += """\
+foo: Foo(a='Value passed from the command-line.')
+bar: Bar(b='default value for `b` from the config_b.yaml file')
+baz: Baz(c="default value for `c` from the Parser's `config_path` (composition_defaults.yaml)")
+"""

--- a/examples/config_files/composition_defaults.yaml
+++ b/examples/config_files/composition_defaults.yaml
@@ -1,0 +1,8 @@
+foo:
+  a: "default value for `a` from the Parser's `config_path` (composition_defaults.yaml)"
+
+bar:
+  b: "default value for `b` from the Parser's `config_path` (composition_defaults.yaml)"
+
+baz:
+  c: "default value for `c` from the Parser's `config_path` (composition_defaults.yaml)"

--- a/examples/config_files/config_a.yaml
+++ b/examples/config_files/config_a.yaml
@@ -1,0 +1,2 @@
+foo:
+  a: "default value for `a` from the config_a.yaml file"

--- a/examples/config_files/config_b.yaml
+++ b/examples/config_files/config_b.yaml
@@ -1,0 +1,2 @@
+bar:
+  b: "default value for `b` from the config_b.yaml file"

--- a/examples/config_files/many_configs.py
+++ b/examples/config_files/many_configs.py
@@ -1,0 +1,56 @@
+import shlex
+from dataclasses import dataclass
+
+import simple_parsing
+
+
+@dataclass
+class TrainConfig:
+    """Training config for Machine Learning"""
+
+    workers: int = 8  # The number of workers for training
+    exp_name: str = "default_exp"  # The experiment name
+
+
+@dataclass
+class EvalConfig:
+    """Evaluation config."""
+
+    n_batches: int = 8  # The number of batches for evaluation
+    checkpoint: str = "best.pth"  # The checkpoint to use
+
+
+def main(args=None) -> None:
+    parser = simple_parsing.ArgumentParser(add_config_path_arg=True)
+
+    parser.add_arguments(TrainConfig, dest="train")
+    parser.add_arguments(EvalConfig, dest="eval")
+
+    if isinstance(args, str):
+        args = shlex.split(args)
+    args = parser.parse_args(args)
+
+    train_config: TrainConfig = args.train
+    eval_config: EvalConfig = args.eval
+    print(f"Training {train_config.exp_name} with {train_config.workers} workers...")
+    print(f"Evaluating '{eval_config.checkpoint}' with {eval_config.n_batches} batches...")
+
+
+main()
+expected = """
+Training default_exp with 8 workers...
+Evaluating 'best.pth' with 8 batches...
+"""
+
+
+main("")
+expected += """\
+Training default_exp with 8 workers...
+Evaluating 'best.pth' with 8 batches...
+"""
+
+main("--config_path many_configs.yaml --exp_name my_first_exp")
+expected += """\
+Training my_first_exp with 42 workers...
+Evaluating 'best.pth' with 100 batches...
+"""

--- a/examples/config_files/many_configs.yaml
+++ b/examples/config_files/many_configs.yaml
@@ -1,0 +1,6 @@
+train:
+  exp_name: my_yaml_exp
+  workers: 42
+eval:
+  checkpoint: best.pth
+  n_batches: 100

--- a/examples/config_files/one_config.py
+++ b/examples/config_files/one_config.py
@@ -1,0 +1,34 @@
+""" Example backported from https://github.com/eladrich/pyrallis#my-first-pyrallis-example- """
+from dataclasses import dataclass
+
+import simple_parsing
+
+
+@dataclass
+class TrainConfig:
+    """Training config for Machine Learning"""
+
+    workers: int = 8  # The number of workers for training
+    exp_name: str = "default_exp"  # The experiment name
+
+
+def main(args=None) -> None:
+    cfg = simple_parsing.parse(config_class=TrainConfig, args=args)
+    print(f"Training {cfg.exp_name} with {cfg.workers} workers...")
+
+
+main()
+expected = """
+Training default_exp with 8 workers...
+"""
+
+main("")
+expected += """\
+Training default_exp with 8 workers...
+"""
+
+# NOTE: When running as in the readme:
+main("--config_path one_config.yaml --exp_name my_first_exp")
+expected += """\
+Training my_first_exp with 42 workers...
+"""

--- a/examples/config_files/one_config.py
+++ b/examples/config_files/one_config.py
@@ -1,4 +1,4 @@
-""" Example backported from https://github.com/eladrich/pyrallis#my-first-pyrallis-example- """
+""" Example adapted from https://github.com/eladrich/pyrallis#my-first-pyrallis-example- """
 from dataclasses import dataclass
 
 import simple_parsing
@@ -6,7 +6,7 @@ import simple_parsing
 
 @dataclass
 class TrainConfig:
-    """Training config for Machine Learning"""
+    """Training configuration."""
 
     workers: int = 8  # The number of workers for training
     exp_name: str = "default_exp"  # The experiment name

--- a/examples/config_files/one_config.yaml
+++ b/examples/config_files/one_config.yaml
@@ -1,0 +1,2 @@
+exp_name: my_yaml_exp
+workers: 42

--- a/examples/serialization/bob.yaml
+++ b/examples/serialization/bob.yaml
@@ -1,4 +1,0 @@
-age: 20
-average_grade: 0.8
-domain: Computer Science
-name: Bob

--- a/examples/subparsers/optional_subparsers.py
+++ b/examples/subparsers/optional_subparsers.py
@@ -40,5 +40,8 @@ def main():
     print(options)
 
 
-if __name__ == "__main__":
-    main()
+main()
+expected = """
+Namespace(options=Options(config=AConfig(foo=123)))
+Options(config=AConfig(foo=123))
+"""

--- a/simple_parsing/__init__.py
+++ b/simple_parsing/__init__.py
@@ -21,6 +21,7 @@ from .parsing import (
     DashVariant,
     NestedMode,
     ParsingError,
+    parse,
 )
 from .utils import InconsistentArgumentError
 

--- a/simple_parsing/helpers/serialization/__init__.py
+++ b/simple_parsing/helpers/serialization/__init__.py
@@ -1,6 +1,24 @@
 from .decoding import *
 from .encoding import *
-from .serializable import FrozenSerializable, Serializable
+from .serializable import (
+    FrozenSerializable,
+    Serializable,
+    SerializableMixin,
+    dump,
+    dump_json,
+    dump_yaml,
+    dumps,
+    dumps_json,
+    dumps_yaml,
+    from_dict,
+    load,
+    load_json,
+    load_yaml,
+    save,
+    save_json,
+    save_yaml,
+    to_dict,
+)
 
 try:
     from .yaml_serialization import YamlSerializable

--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -8,6 +8,7 @@ from dataclasses import Field
 from enum import Enum
 from functools import lru_cache, partial
 from logging import getLogger
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
 
 from simple_parsing.annotation_utils.get_field_annotations import (
@@ -444,3 +445,6 @@ def try_constructor(t: Type[T]) -> Callable[[Any], Union[T, Any]]:
             return t(val)
 
     return try_functions(constructor)
+
+
+register_decoding_fn(Path, Path)

--- a/simple_parsing/helpers/serialization/serializable.py
+++ b/simple_parsing/helpers/serialization/serializable.py
@@ -653,12 +653,14 @@ def to_dict(dc, dict_factory: type[dict] = dict, recurse: bool = True) -> dict:
             continue
 
         encoding_fn = encode
-        if isinstance(value, SerializableMixin) and recurse:
+        # TODO: Make a variant of the serialization tests that use the static functions everywhere.
+        # This if statement here shouldn't be there.
+        if is_dataclass(value) and recurse:
             try:
-                encoded = value.to_dict(dict_factory=dict_factory, recurse=recurse)
+                encoded = to_dict(value, dict_factory=dict_factory, recurse=recurse)
             except TypeError:
-                encoded = value.to_dict()
-            logger.debug(f"Encoded Serializable field {name}: {encoded}")
+                encoded = to_dict(value)
+            logger.debug(f"Encoded dataclass field {name}: {encoded}")
         else:
             try:
                 encoded = encoding_fn(value)

--- a/simple_parsing/helpers/serialization/serializable.py
+++ b/simple_parsing/helpers/serialization/serializable.py
@@ -654,7 +654,6 @@ def to_dict(dc, dict_factory: type[dict] = dict, recurse: bool = True) -> dict:
 
         encoding_fn = encode
         # TODO: Make a variant of the serialization tests that use the static functions everywhere.
-        # This if statement here shouldn't be there.
         if is_dataclass(value) and recurse:
             try:
                 encoded = to_dict(value, dict_factory=dict_factory, recurse=recurse)

--- a/simple_parsing/helpers/serialization/yaml_serialization.py
+++ b/simple_parsing/helpers/serialization/yaml_serialization.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from logging import getLogger
 from pathlib import Path
-from typing import IO, Type, Union
+from typing import IO
 
 import yaml
 
@@ -26,22 +28,30 @@ class YamlSerializable(Serializable):
 
     @classmethod
     def load(
-        cls: Type[D],
-        path: Union[Path, str, IO[str]],
-        drop_extra_fields: bool = None,
+        cls: type[D],
+        path: Path | str | IO[str],
+        drop_extra_fields: bool | None = None,
         load_fn=yaml.safe_load,
-        **kwargs
+        **kwargs,
     ) -> D:
         return super().load(path, drop_extra_fields=drop_extra_fields, load_fn=load_fn, **kwargs)
 
     @classmethod
     def loads(
-        cls: Type[D], s: str, drop_extra_fields: bool = None, load_fn=yaml.safe_load, **kwargs
+        cls: type[D],
+        s: str,
+        drop_extra_fields: bool | None = None,
+        load_fn=yaml.safe_load,
+        **kwargs,
     ) -> D:
         return super().loads(s, drop_extra_fields=drop_extra_fields, load_fn=load_fn, **kwargs)
 
     @classmethod
     def _load(
-        cls: Type[D], fp: IO[str], drop_extra_fields: bool = None, load_fn=yaml.safe_load, **kwargs
+        cls: type[D],
+        fp: IO[str],
+        drop_extra_fields: bool | None = None,
+        load_fn=yaml.safe_load,
+        **kwargs,
     ) -> D:
         return super()._load(fp, drop_extra_fields=drop_extra_fields, load_fn=load_fn, **kwargs)

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -153,7 +153,10 @@ class ArgumentParser(argparse.ArgumentParser):
                 add_arguments_call(self)
 
         self.config_path = Path(config_path) if isinstance(config_path, str) else config_path
-        self.add_config_path_arg = add_config_path_arg or bool(config_path)
+        if add_config_path_arg is None:
+            # By default, add a config path argument if a config path was passed.
+            add_config_path_arg = bool(config_path)
+        self.add_config_path_arg = add_config_path_arg
 
     def add_argument(
         self,

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -850,39 +850,13 @@ def parse(
 
     If `config_path` is passed, loads the values from that file and uses them as defaults.
     """
-    from simple_parsing.helpers.serialization.serializable import load
 
     if isinstance(args, str):
         args = shlex.split(args)
-
-    default_config_path = config_path
-    # First parser is only made for retrieving the config path.
-    config_path_parser = ArgumentParser(add_help=False)
-    config_path_parser.add_argument(
-        "--config_path",
-        type=Path,
-        default=default_config_path,
-        help="path to a config file to use for default values.",
+    parser = ArgumentParser(
+        nested_mode=NestedMode.WITHOUT_ROOT, add_help=True, add_config_path_arg=True
     )
-    parsed_args, unused_args = config_path_parser.parse_known_args(args)
-    config_path = parsed_args.config_path
-    if config_path:
-        # If passed, use the config path argument to get the defaults for that dataclass.
-        defaults = load(config_class, config_path)
-    else:
-        defaults = None
-
-    # Parse the actual arguments.
-    parser = ArgumentParser(nested_mode=NestedMode.WITHOUT_ROOT, add_help=True)
-    # NOTE: Only add it here so the --help text also includes the --config-path argument.
-    parser.add_argument(
-        "--config_path",
-        type=Path,
-        default=default_config_path,
-        help="path to a config file to use for default values.",
-    )
-    parser.add_arguments(config_class, dest="config", default=defaults)
-
-    parsed_args = parser.parse_args(unused_args)
+    parser.add_arguments(config_class, dest="config")
+    parsed_args = parser.parse_args(args)
     config: Dataclass = parsed_args.config
     return config

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -549,8 +549,6 @@ class ArgumentParser(argparse.ArgumentParser):
 
         for option_string in self._help_action.option_strings:
             self._option_string_actions.pop(option_string)
-        # assert False, self._option_string_actions
-        # optionals_help_actions = [action for action in self._optionals._actions]
 
     def _postprocessing(self, parsed_args: Namespace) -> Namespace:
         """Process the namespace by extract the fields and creating the objects.

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -302,7 +302,6 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
                 _arg_options["type"] = get_parsing_fn(wrapped_type)
                 # TODO: Should the 'nargs' really be '?' here?
                 _arg_options["nargs"] = "?"
-                # assert False, (wrapped_type, utils.is_tuple(wrapped_type))
 
         elif self.is_union:
             logger.debug("Parsing a Union type!")

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -191,6 +191,7 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
             parent_dest, attribute = utils.split_dest(destination)
             value = self.postprocess(value)
             self._results[destination] = value
+
             parser.constructor_arguments[parent_dest][attribute] = value
             logger.debug(
                 f"setting value of {value} in constructor arguments "

--- a/test/test_set_defaults.py
+++ b/test/test_set_defaults.py
@@ -1,0 +1,20 @@
+""" Tests for the setdefaults method of the parser. """
+from dataclasses import dataclass
+
+from simple_parsing.parsing import ArgumentParser
+
+from .testutils import TestSetup
+
+
+@dataclass
+class Foo(TestSetup):
+    a: int = 123
+    b: str = "hello"
+
+
+def test_set_defaults():
+    parser = ArgumentParser()
+    parser.add_arguments(Foo, dest="foo")
+    parser.set_defaults(foo=Foo(b="HOLA"))
+    args = parser.parse_args("")
+    assert args.foo == Foo(b="HOLA")

--- a/test/test_set_defaults.py
+++ b/test/test_set_defaults.py
@@ -1,6 +1,10 @@
 """ Tests for the setdefaults method of the parser. """
 from dataclasses import dataclass
+from pathlib import Path
 
+import yaml
+
+from simple_parsing.helpers.serialization.serializable import to_dict
 from simple_parsing.parsing import ArgumentParser
 
 from .testutils import TestSetup
@@ -18,3 +22,31 @@ def test_set_defaults():
     parser.set_defaults(foo=Foo(b="HOLA"))
     args = parser.parse_args("")
     assert args.foo == Foo(b="HOLA")
+
+
+def test_set_defaults_from_file(tmp_path: Path):
+    parser = ArgumentParser()
+    parser.add_arguments(Foo, dest="foo")
+
+    saved_config = Foo(a=456, b="HOLA")
+    config_path = tmp_path / "foo.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump({"foo": to_dict(saved_config)}, f)
+
+    parser.set_defaults(config_path)
+    args = parser.parse_args("")
+    assert args.foo == saved_config
+
+
+def test_set_defaults_from_file_before_adding_args(tmp_path: Path):
+    parser = ArgumentParser()
+
+    saved_config = Foo(a=456, b="HOLA")
+    config_path = tmp_path / "foo.yaml"
+    with open(config_path, "w") as f:
+        yaml.dump({"foo": to_dict(saved_config)}, f)
+    parser.set_defaults(config_path)
+
+    parser.add_arguments(Foo, dest="foo")
+    args = parser.parse_args("")
+    assert args.foo == saved_config

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Set, Tuple, Type
 import simple_parsing.utils as utils
 from simple_parsing import mutable_field
 from simple_parsing.helpers import dict_field, list_field, set_field
+from simple_parsing.utils import flatten_join, unflatten_split
 
 from .testutils import TestSetup, parametrize
 
@@ -167,3 +168,23 @@ def test_dict_field_without_args():
     a2 = A()
     assert a1.a == a2.a == default
     assert id(a1.a) != id(a2.a)
+
+
+def test_flatten():
+    """Test basic functionality of flatten"""
+    d = {"a": {"b": 2, "c": 3}, "c": {"d": 3, "e": 4}}
+    assert flatten_join(d) == {"a.b": 2, "a.c": 3, "c.d": 3, "c.e": 4}
+
+
+def test_flatten_double_ref():
+    """Test proper handling of double references in dicts"""
+    a = {"b": 2, "c": 3}
+    d = {"a": a, "d": {"e": a}}
+    assert flatten_join(d) == {"a.b": 2, "a.c": 3, "d.e.b": 2, "d.e.c": 3}
+
+
+def test_unflatten():
+    """Test than unflatten(flatten(x)) is idempotent"""
+    a = {"b": 2, "c": 3}
+    d = {"a": a, "d": {"e": a}}
+    assert unflatten_split(flatten_join(d)) == d


### PR DESCRIPTION
Closes #45 

- adds better support for setting the argument defaults from the command-line.
- re-adds the `add_dest_to_option_strings` argument. (Closes #131)
- Add 'static' equivalent to all the serialization methods of the `Serializable` class.


See the example file here:

https://github.com/lebrice/SimpleParsing/blob/config-file/examples/config_files/README.md
