### PR TITLE
Alias prefix suppression

### DIFF
--- a/simple_parsing/__init__.py
+++ b/simple_parsing/__init__.py
@@ -5,6 +5,7 @@ from . import helpers, utils, wrappers
 from .conflicts import ConflictResolution
 from .help_formatter import SimpleHelpFormatter
 from .helpers import (
+    Alias,
     MutableField,
     Serializable,
     choice,
@@ -45,6 +46,7 @@ __all__ = [
     "ParsingError",
     "ArgumentGenerationMode",
     "NestedMode",
+    "Alias",
     "InconsistentArgumentError",
 ]
 

--- a/simple_parsing/helpers/fields.py
+++ b/simple_parsing/helpers/fields.py
@@ -32,10 +32,14 @@ K = TypeVar("K")
 V = TypeVar("V")
 T = TypeVar("T")
 
+@dataclasses.dataclass
+class Alias:
+    name: str
+    suppress_prefix: bool = False
 
 def field(
     default: Union[T, _MISSING_TYPE] = MISSING,
-    alias: Optional[Union[str, List[str]]] = None,
+    alias: Optional[Union[str, Alias, List[str], List[Alias]]] = None,
     cmd: bool = True,
     positional: bool = False,
     *,
@@ -64,11 +68,13 @@ def field(
     ----------
     default : Union[T, _MISSING_TYPE], optional
         The default field value (same as in `dataclasses.field`), by default MISSING
-    alias : Union[str, List[str]], optional
+    alias : Union[str, Alias, List[str], List[Alias]], optional
         Additional option_strings to pass to the `add_argument` method, by
-        default None. When passing strings which do not start by "-" or "--",
+        default None. When passing aliases which do not start by "-" or "--",
         will be prefixed with "-" if the string is one character and by "--"
-        otherwise.
+        otherwise. Using the Alias class allows to suppress the prefix defined
+        for the dataclass to make the corresponding command line switch extra short
+        (e.g. "-l" instead of "--experiment_label").
     cmd: bool, optional
         Whether to add command-line arguments for this field or not. Defaults to
         True.

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -13,6 +13,7 @@ from .. import docstring, utils
 from .field_metavar import get_metavar
 from .field_parsing import get_parsing_fn
 from .wrapper import Wrapper
+from ..helpers import Alias
 
 if typing.TYPE_CHECKING:
     from simple_parsing import ArgumentParser
@@ -603,16 +604,23 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
 
         # add all the aliases that were passed to the `field` function.
         for alias in self.aliases:
-            if alias.startswith("--"):
+            if isinstance(alias, Alias):
+                name = alias.name
+            else:
+                name = alias
+            if name.startswith("--"):
                 dash = "--"
-                name = alias[2:]
-            elif alias.startswith("-"):
+                name = name[2:]
+            elif name.startswith("-"):
                 dash = "-"
-                name = alias[1:]
+                name = name[1:]
             else:
                 dash = "-" if len(alias) == 1 else "--"
                 name = alias
-            option = f"{self.prefix}{name}"
+            if isinstance(alias, Alias) and alias.suppress_prefix:
+                option = name
+            else:
+                option = f"{self.prefix}{name}"
 
             dashes.append(dash)
             options.append(option)

--- a/test/test_aliases.py
+++ b/test/test_aliases.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from test.testutils import TestSetup
 
-from simple_parsing import field
+from simple_parsing import field, Alias
+from test.testutils import TestSetup, raises_unrecognized_args, raises_ambiguous_option
 
 
 def test_aliases_with_given_dashes():
@@ -15,8 +15,14 @@ def test_aliases_with_given_dashes():
     foo = Foo.setup("-o /cat")
     assert foo.output_dir == "/cat"
 
+    with raises_ambiguous_option():
+        Foo.setup("--o /cake")
+
     foo = Foo.setup("--out /john")
     assert foo.output_dir == "/john"
+
+    with raises_unrecognized_args():
+        Foo.setup("-out /joe")
 
 
 def test_aliases_without_dashes():
@@ -30,5 +36,64 @@ def test_aliases_without_dashes():
     foo = Foo.setup("-o /cat")
     assert foo.output_dir == "/cat"
 
+    with raises_ambiguous_option():
+        Foo.setup("--o /cat")
+
+    with raises_unrecognized_args():
+        Foo.setup("-out /john")
+
     foo = Foo.setup("--out /john")
+    assert foo.output_dir == "/john"
+
+
+def test_aliases_with_unsuppressed_prefix():
+    @dataclass
+    class Foo(TestSetup):
+        output_dir: str = field(default="/out", alias=[Alias("-o"), Alias("--out")])
+
+    foo = Foo.setup("--prefix_output_dir /bob", prefix="prefix_")
+    assert foo.output_dir == "/bob"
+
+    with raises_unrecognized_args():
+        Foo.setup("--output_dir /bob", prefix="prefix_")
+
+    foo = Foo.setup("-prefix_o /cat", prefix="prefix_")
+    assert foo.output_dir == "/cat"
+
+    with raises_unrecognized_args():
+        Foo.setup("-o /cat", prefix="prefix_")
+
+    foo = Foo.setup("--prefix_out /john", prefix="prefix_")
+    assert foo.output_dir == "/john"
+
+    with raises_unrecognized_args():
+        Foo.setup("--out /john", prefix="prefix_")
+
+
+def test_aliases_with_suppressed_prefix():
+    @dataclass
+    class Foo(TestSetup):
+        output_dir: str = field(default="/out",
+                                alias=[Alias("-o", suppress_prefix=True),
+                                       Alias("--out", suppress_prefix=True)])
+
+    foo = Foo.setup("--prefix_output_dir /bob", prefix="prefix_")
+    assert foo.output_dir == "/bob"
+
+    with raises_unrecognized_args():
+        Foo.setup("--output_dir /bob", prefix="prefix_")
+
+    foo = Foo.setup("-o /cat", prefix="prefix_")
+    assert foo.output_dir == "/cat"
+
+    foo = Foo.setup("--o /cake", prefix="prefix_")
+    assert foo.output_dir == "/cake"
+
+    with raises_unrecognized_args():
+        Foo.setup("-prefix_o /bob", prefix="prefix_")
+
+    foo = Foo.setup("--prefix_o /bob", prefix="prefix_")
+    assert foo.output_dir == "/bob"
+
+    foo = Foo.setup("--out /john", prefix="prefix_")
     assert foo.output_dir == "/john"

--- a/test/testutils.py
+++ b/test/testutils.py
@@ -79,6 +79,12 @@ def raises_unrecognized_args(*args: str):
         yield
 
 
+@contextmanager
+def raises_ambiguous_option(*args: str):
+    with exits_and_writes_to_stderr("ambiguous option: " + " ".join(args or [])):
+        yield
+
+
 def assert_help_output_equals(actual: str, expected: str) -> None:
     # Replace the start with `prog`, since the test runner might not always be
     # `pytest`, could also be __main__ when debugging with VSCode
@@ -131,6 +137,7 @@ class TestSetup:
         arguments: Optional[str] = "",
         dest: Optional[str] = None,
         default: Optional[Dataclass] = None,
+        prefix: Optional[str] = "",
         conflict_resolution_mode: ConflictResolution = ConflictResolution.AUTO,
         add_option_string_dash_variants: DashVariant = DashVariant.AUTO,
         parse_known_args: bool = False,
@@ -157,7 +164,7 @@ class TestSetup:
         if dest is None:
             dest = camel_case(cls.__name__)
 
-        parser.add_arguments(cls, dest=dest, default=default)
+        parser.add_arguments(cls, dest=dest, default=default, prefix=prefix)
 
         if arguments is None:
             if parse_known_args:


### PR DESCRIPTION
Allow to suppress the prefix defined for a field if used through an alias, for extra-short aliases for often-used command line switches.