### PR TITLE
Fix bug in docstring parsing, docstrings inherit from bases

### DIFF
--- a/simple_parsing/docstring.py
+++ b/simple_parsing/docstring.py
@@ -64,7 +64,7 @@ def get_attribute_docstring(
                 created_docstring.docstring_below or attribute_docstring.docstring_below
             )
     if not created_docstring:
-        logger.warning(
+        logger.debug(
             RuntimeWarning(
                 f"Couldn't find the definition for field '{field_name}' within the dataclass "
                 f"{dataclass} or any of its base classes {','.join(map(str, mro[1:]))}."

--- a/simple_parsing/docstring.py
+++ b/simple_parsing/docstring.py
@@ -67,7 +67,7 @@ def get_attribute_docstring(
         logger.debug(
             RuntimeWarning(
                 f"Couldn't find the definition for field '{field_name}' within the dataclass "
-                f"{dataclass} or any of its base classes {','.join(map(str, mro[1:]))}."
+                f"{dataclass} or any of its base classes {','.join(t.__name__ for t in mro[1:])}."
             )
         )
         return AttributeDocString()

--- a/simple_parsing/docstring.py
+++ b/simple_parsing/docstring.py
@@ -1,10 +1,11 @@
 """Utility for retrieveing the docstring of a dataclass's attributes
 @author: Fabrice Normandin
 """
+from __future__ import annotations
+
 import inspect
 from dataclasses import dataclass
 from logging import getLogger
-from typing import List, Optional, Type
 
 logger = getLogger(__name__)
 
@@ -18,7 +19,7 @@ class AttributeDocString:
     docstring_below: str = ""
 
 
-def get_attribute_docstring(some_dataclass: Type, field_name: str) -> AttributeDocString:
+def get_attribute_docstring(some_dataclass: type, field_name: str) -> AttributeDocString:
     """Returns the docstrings of a dataclass field.
     NOTE: a docstring can either be:
     - An inline comment, starting with <#>
@@ -38,7 +39,7 @@ def get_attribute_docstring(some_dataclass: Type, field_name: str) -> AttributeD
         logger.debug(f"Couldn't find the attribute docstring: {e}")
         return AttributeDocString()
 
-    code_lines: List[str] = source.splitlines()
+    code_lines: list[str] = source.splitlines()
     # the first line is the class definition, we skip it.
     start_line_index = 1
     # starting at the second line, there might be the docstring for the class.
@@ -54,7 +55,7 @@ def get_attribute_docstring(some_dataclass: Type, field_name: str) -> AttributeD
         if _contains_attribute_definition(line)
     ]
     for i, line in lines_with_attribute_defs:
-        parts: List[str] = line.split(":", maxsplit=1)
+        parts: list[str] = line.split(":", maxsplit=1)
         if parts[0].strip() == field_name:
             # we found the line with the definition of this field.
             comment_above = _get_comment_ending_at_line(code_lines, i - 1)
@@ -107,7 +108,7 @@ def _is_comment(line_str: str) -> bool:
     return line_str.strip().startswith("#")
 
 
-def _get_comment_at_line(code_lines: List[str], line: int) -> str:
+def _get_comment_at_line(code_lines: list[str], line: int) -> str:
     """Gets the comment at line `line` in `code_lines`.
 
     Arguments:
@@ -125,7 +126,7 @@ def _get_comment_at_line(code_lines: List[str], line: int) -> str:
     return comment
 
 
-def _get_inline_comment_at_line(code_lines: List[str], line: int) -> str:
+def _get_inline_comment_at_line(code_lines: list[str], line: int) -> str:
     """Gets the inline comment at line `line`.
 
     Arguments:
@@ -144,7 +145,7 @@ def _get_inline_comment_at_line(code_lines: List[str], line: int) -> str:
     return comment
 
 
-def _get_comment_ending_at_line(code_lines: List[str], line: int) -> str:
+def _get_comment_ending_at_line(code_lines: list[str], line: int) -> str:
     start_line = line
     end_line = line
     # print(f"Get comment ending at line {line}")
@@ -173,9 +174,9 @@ def _get_comment_ending_at_line(code_lines: List[str], line: int) -> str:
     return "\n".join(lines)
 
 
-def _get_docstring_starting_at_line(code_lines: List[str], line: int) -> str:
+def _get_docstring_starting_at_line(code_lines: list[str], line: int) -> str:
     i = line
-    token: Optional[str] = None
+    token: str | None = None
     triple_single = "'''"
     triple_double = '"""'
     # print("finding docstring starting from line", line)
@@ -185,7 +186,7 @@ def _get_docstring_starting_at_line(code_lines: List[str], line: int) -> str:
     if line >= len(code_lines):
         return ""
     # the list of lines making up the docstring.
-    docstring_contents: List[str] = []
+    docstring_contents: list[str] = []
 
     while i <= len(code_lines):
         line_str = code_lines[i]

--- a/simple_parsing/helpers/hparams/hyperparameters_test.py
+++ b/simple_parsing/helpers/hparams/hyperparameters_test.py
@@ -265,6 +265,6 @@ def test_field_types():
     assert C.get_priors()["f"].discrete is True
 
     if numpy_installed:
-        assert all(c.f.dtype == np.int for c in cs)
+        assert all(c.f.dtype == int for c in cs)
     else:
         assert all(all(isinstance(v, int) for v in c.f) for c in cs)

--- a/test/test_conflicts.py
+++ b/test/test_conflicts.py
@@ -74,10 +74,10 @@ def test_parent_child_conflict():
         batch_size: int = 32
 
     @dataclass
-    class Parent(TestSetup):
+    class Parent2(TestSetup):
         batch_size: int = 48
         child: HParams = HParams()
 
-    p: Parent = Parent.setup()
+    p: Parent2 = Parent2.setup()
     assert p.child.batch_size == 32
     assert p.batch_size == 48

--- a/test/test_docstrings.py
+++ b/test/test_docstrings.py
@@ -98,6 +98,8 @@ def test_docstring_works_with_field_function():
 
 
 def test_docstrings_with_multiple_inheritance():
+    """Test to reproduce issue 162: https://github.com/lebrice/SimpleParsing/issues/162"""
+
     @dataclass
     class Fooz:
         bar: int = 123  #: The bar property

--- a/test/test_docstrings.py
+++ b/test/test_docstrings.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List
 
 from simple_parsing import field
-from simple_parsing.docstring import get_attribute_docstring
+from simple_parsing.docstring import AttributeDocString, get_attribute_docstring
 
 from .testutils import TestSetup
 
@@ -95,3 +95,27 @@ def test_docstring_works_with_field_function():
     assert docstring.comment_above == "A sequence of tasks."
     assert docstring.comment_inline == "side"
     assert docstring.docstring_below == "Below"
+
+
+def test_docstrings_with_multiple_inheritance():
+    @dataclass
+    class Foo:
+        bar: int = 123  #: The bar property
+
+    @dataclass
+    class Baz:
+        bat: int = 123  #: The bat property
+
+    @dataclass
+    class FooBaz(Foo, Baz):
+        foobaz: int = 123  #: The foobaz property
+
+    assert get_attribute_docstring(FooBaz, "foobaz") == AttributeDocString(
+        comment_inline=": The foobaz property"
+    )
+    assert get_attribute_docstring(FooBaz, "bar") == AttributeDocString(
+        comment_inline=": The bar property"
+    )
+    assert get_attribute_docstring(FooBaz, "bat") == AttributeDocString(
+        comment_inline=": The bat property"
+    )

--- a/test/test_docstrings.py
+++ b/test/test_docstrings.py
@@ -110,12 +110,12 @@ def test_docstrings_with_multiple_inheritance():
     class FooBaz(Foo, Baz):
         foobaz: int = 123  #: The foobaz property
 
-    assert get_attribute_docstring(FooBaz, "foobaz") == AttributeDocString(
-        comment_inline=": The foobaz property"
-    )
     assert get_attribute_docstring(FooBaz, "bar") == AttributeDocString(
         comment_inline=": The bar property"
     )
     assert get_attribute_docstring(FooBaz, "bat") == AttributeDocString(
         comment_inline=": The bat property"
+    )
+    assert get_attribute_docstring(FooBaz, "foobaz") == AttributeDocString(
+        comment_inline=": The foobaz property"
     )

--- a/test/test_docstrings.py
+++ b/test/test_docstrings.py
@@ -119,3 +119,43 @@ def test_docstrings_with_multiple_inheritance():
     assert get_attribute_docstring(FooBaz, "foobaz") == AttributeDocString(
         comment_inline=": The foobaz property"
     )
+
+
+def test_weird_docstring_with_field_like():
+    @dataclass
+    class Foo:
+        """
+        @dataclass
+        class weird:
+            bar: int = 123  # WRONG DOCSTRING
+        """
+
+        bar: int = 123  # The bar property
+
+    assert get_attribute_docstring(Foo, "bar") == AttributeDocString(
+        comment_inline="The bar property"
+    )
+
+
+def test_docstring_builds_upon_bases():
+    @dataclass
+    class Base:
+        """
+        # WRONG ABOVE
+        bar: int = 333 # WRONG INLINE
+        '''WRONG DOCSTRING'''
+        """
+
+        bar: int = 123  # inline
+        """docstring"""
+
+    @dataclass
+    class Foo(Base):
+        # Above
+        bar: int = 123  # The bar property
+
+    assert get_attribute_docstring(Foo, "bar") == AttributeDocString(
+        comment_inline="The bar property",
+        comment_above="Above",
+        docstring_below="docstring",
+    )


### PR DESCRIPTION
- Fixes #162 
- Field docstrings components are now inherited from the base classes. 
```python
@dataclass
class Base:
    bar: int = 123  # inline
    """field docstring from base class"""

@dataclass
class Foo(Base):
    # Above
    bar: int = 123  # The bar property

assert get_attribute_docstring(Foo, "bar") == AttributeDocString(
    comment_inline="The bar property",
    comment_above="Above",
    docstring_below="field docstring from base class",
)
```

--help text:
```
usage: pytest [-h] [--bar int]

optional arguments:
  -h, --help  show this help message and exit

Foo ['foo']:
  Foo(bar: int = 123)

  --bar int   field docstring from base class (default: 123)
```

