### PR TITLE
Update the readme to feature the `parse` api, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ Using [dataclasses](https://docs.python.org/3.7/library/dataclasses.html), `simp
 Supports inheritance, **nesting**, easy serialization to json/yaml, automatic help strings from comments, and much more!
 
 ```python
-# examples/demo_simple.py
+# examples/demo.py
 from dataclasses import dataclass
-import simple_parsing
+from simple_parsing import ArgumentParser
+
+parser = ArgumentParser()
+parser.add_argument("--foo", type=int, default=123, help="foo help")
 
 @dataclass
 class Options:
@@ -19,52 +22,42 @@ class Options:
     log_dir: str                # Help string for a required str argument
     learning_rate: float = 1e-4 # Help string for a float argument
 
-options: Options = simple_parsing.parse(Options)
-print(f"options: {options}")
+parser.add_arguments(Options, dest="options")
+
+args = parser.parse_args()
+print("foo:", args.foo)
+print("options:", args.options)
 ```
 ```console
-$ python examples/demo_simple.py --log_dir logs
+$ python examples/demo.py --log_dir logs --foo 123
+foo: 123
 options: Options(log_dir='logs', learning_rate=0.0001)
 ```
 ```console
-$ python examples/demo_simple.py --help
-usage: demo_simple.py [-h] [--config_path Path] --log_dir str [--learning_rate float]
+$ python examples/demo.py --help
+usage: demo.py [-h] [--foo int] --log_dir str [--learning_rate float]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --config_path Path    Path to a config file containing default values to use. (default: None)
+  --foo int             foo help (default: 123)
 
-Options ['config']:
-  Help string for this group of command-line arguments
+Options ['options']:
+   Help string for this group of command-line arguments
 
-  --log_dir str         Help string for a required str argument (default: None)
+  --log_dir str         Help string for a required str argument (default:
+                        None)
   --learning_rate float
                         Help string for a float argument (default: 0.0001)
 ```
 
+### (*new*) Simplified API:
 
-Simple-Parsing is an extension of python's Argparse library, so you can mix and match the two.
-Simple-Parsing helps you transitition from old argparse-style code to new, beautiful, typed-out code:
-simply convert blocks of argparse code into dataclasses, and let Simple-Parsing do the rest!
+For a simple use-case, where you only want to parse a single dataclass, you can use the `simple_parsing.parse` or `simple_parsing.parse_known_args` functions:
 
 ```python
-# examples/demo.py
-from dataclasses import dataclass
-from simple_parsing import ArgumentParser
-
-parser = ArgumentParser()
-# Adding a regular argparse-style argument
-parser.add_argument("--foo", type=int, default=123, help="foo help")
-# Adding a group of arguments (a dataclass) using Simple-Parsing!
-parser.add_arguments(Options, dest="options")
-
-# Parsing args as usual with argparse:
-args = parser.parse_args()
-
-foo: int = args.foo
-options: Options = args.options
+options: Options = simple_parsing.parse(Options)
+options, leftover_args = simple_parsing.parse_known_args(Options)
 ```
-
 
 
 ## installation

--- a/README.md
+++ b/README.md
@@ -9,12 +9,9 @@ Using [dataclasses](https://docs.python.org/3.7/library/dataclasses.html), `simp
 Supports inheritance, **nesting**, easy serialization to json/yaml, automatic help strings from comments, and much more!
 
 ```python
-# examples/demo.py
+# examples/demo_simple.py
 from dataclasses import dataclass
-from simple_parsing import ArgumentParser
-
-parser = ArgumentParser()
-parser.add_argument("--foo", type=int, default=123, help="foo help")
+import simple_parsing
 
 @dataclass
 class Options:
@@ -22,33 +19,52 @@ class Options:
     log_dir: str                # Help string for a required str argument
     learning_rate: float = 1e-4 # Help string for a float argument
 
-parser.add_arguments(Options, dest="options")
-
-args = parser.parse_args()
-print("foo:", args.foo)
-print("options:", args.options)
+options: Options = simple_parsing.parse(Options)
+print(f"options: {options}")
 ```
 ```console
-$ python examples/demo.py --log_dir logs --foo 123
-foo: 123
+$ python examples/demo_simple.py --log_dir logs
 options: Options(log_dir='logs', learning_rate=0.0001)
 ```
 ```console
-$ python examples/demo.py --help
-usage: demo.py [-h] [--foo int] --log_dir str [--learning_rate float]
+$ python examples/demo_simple.py --help
+usage: demo_simple.py [-h] [--config_path Path] --log_dir str [--learning_rate float]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --foo int             foo help (default: 123)
+  --config_path Path    Path to a config file containing default values to use. (default: None)
 
-Options ['options']:
-   Help string for this group of command-line arguments
+Options ['config']:
+  Help string for this group of command-line arguments
 
-  --log_dir str         Help string for a required str argument (default:
-                        None)
+  --log_dir str         Help string for a required str argument (default: None)
   --learning_rate float
                         Help string for a float argument (default: 0.0001)
 ```
+
+
+Simple-Parsing is an extension of python's Argparse library, so you can mix and match the two.
+Simple-Parsing helps you transitition from old argparse-style code to new, beautiful, typed-out code:
+simply convert blocks of argparse code into dataclasses, and let Simple-Parsing do the rest!
+
+```python
+# examples/demo.py
+from dataclasses import dataclass
+from simple_parsing import ArgumentParser
+
+parser = ArgumentParser()
+# Adding a regular argparse-style argument
+parser.add_argument("--foo", type=int, default=123, help="foo help")
+# Adding a group of arguments (a dataclass) using Simple-Parsing!
+parser.add_arguments(Options, dest="options")
+
+# Parsing args as usual with argparse:
+args = parser.parse_args()
+
+foo: int = args.foo
+options: Options = args.options
+```
+
 
 
 ## installation

--- a/examples/config_files/one_config.py
+++ b/examples/config_files/one_config.py
@@ -13,7 +13,7 @@ class TrainConfig:
 
 
 def main(args=None) -> None:
-    cfg = simple_parsing.parse(config_class=TrainConfig, args=args)
+    cfg = simple_parsing.parse(config_class=TrainConfig, args=args, add_config_path_arg=True)
     print(f"Training {cfg.exp_name} with {cfg.workers} workers...")
 
 

--- a/examples/demo_simple.py
+++ b/examples/demo_simple.py
@@ -1,0 +1,16 @@
+# examples/demo_simple.py
+from dataclasses import dataclass
+
+import simple_parsing
+
+
+@dataclass
+class Options:
+    """Help string for this group of command-line arguments"""
+
+    log_dir: str  # Help string for a required str argument
+    learning_rate: float = 1e-4  # Help string for a float argument
+
+
+options = simple_parsing.parse(Options)
+print(options)

--- a/simple_parsing/__init__.py
+++ b/simple_parsing/__init__.py
@@ -22,6 +22,7 @@ from .parsing import (
     NestedMode,
     ParsingError,
     parse,
+    parse_known_args,
 )
 from .utils import InconsistentArgumentError
 
@@ -44,6 +45,7 @@ __all__ = [
     "DashVariant",
     "ParsingError",
     "parse",
+    "parse_known_args",
     "ArgumentGenerationMode",
     "NestedMode",
     "InconsistentArgumentError",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,9 +3,10 @@ import os
 import sys
 from dataclasses import dataclass
 from logging import getLogger as get_logger
-from typing import Any, ClassVar, List, Literal, NamedTuple, Optional, Tuple, Type
+from typing import Any, ClassVar, List, NamedTuple, Optional, Tuple, Type
 
 import pytest
+from typing_extensions import Literal
 
 from simple_parsing import choice
 from simple_parsing.helpers import Serializable

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,9 @@
 import logging
+import os
 import sys
 from dataclasses import dataclass
 from logging import getLogger as get_logger
-from typing import Any, ClassVar, List, NamedTuple, Optional, Tuple, Type
+from typing import Any, ClassVar, List, Literal, NamedTuple, Optional, Tuple, Type
 
 import pytest
 
@@ -55,6 +56,13 @@ def simple_attribute(request):
     return SimpleAttributeTuple(
         field_type=some_type, passed_value=passed_value, expected_value=expected_value
     )
+
+
+@pytest.fixture(autouse=True, params=["simple", "verbose"])
+def simple_and_advanced_api(request, monkeypatch):
+    api: Literal["simple", "verbose"] = request.param
+    monkeypatch.setitem(os.environ, "SIMPLE_PARSING_API", api)
+    yield
 
 
 @pytest.fixture

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,20 +1,18 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
-from dataclasses import dataclass
 from logging import getLogger as get_logger
-from typing import Any, ClassVar, List, NamedTuple, Optional, Tuple, Type
+from typing import Any, NamedTuple
 
 import pytest
 from typing_extensions import Literal
 
-from simple_parsing import choice
-from simple_parsing.helpers import Serializable
-
 pytest.register_assert_rewrite("test.testutils")
 
 # List of simple attributes to use in test:
-simple_arguments: List[Tuple[Type, Any, Any]] = [
+simple_arguments: list[tuple[type, Any, Any]] = [
     # type, passed value, expected (parsed) value
     (int, "123", 123),
     (int, 123, 123),
@@ -42,7 +40,7 @@ simple_arguments: List[Tuple[Type, Any, Any]] = [
 
 
 class SimpleAttributeTuple(NamedTuple):
-    field_type: Type
+    field_type: type
     passed_value: str
     expected_value: Any
 
@@ -71,7 +69,7 @@ def assert_equals_stdout(capsys):
     def strip(string):
         return "".join(string.split())
 
-    def should_equal(expected: str, file_path: Optional[str] = None):
+    def should_equal(expected: str, file_path: str | None = None):
         if "optional arguments" in expected and sys.version_info >= (3, 10):
             expected = expected.replace("optional arguments", "options")
         out = capsys.readouterr().out
@@ -148,108 +146,3 @@ def logs_warning(caplog):
     messages = [x.message for x in caplog.get_records("call") if x.levelno == logging.WARNING]
     if not messages:
         pytest.fail(f"No warning messages were logged: {messages}")
-
-
-@pytest.fixture
-def TaskHyperParameters():
-    """Test fixture that gives a good example use-case from a real datascience
-    project.
-    """
-    from .testutils import TestSetup
-
-    @dataclass
-    class TaskHyperParameters(TestSetup, Serializable):
-        """
-        HyperParameters for a task-specific model
-        """
-
-        name: str  # name of the task
-        num_layers: int = 1  # number of dense layers
-        num_units: int = 8  # units per layer
-        activation: str = choice("tanh", "relu", "linear", default="tanh")  # activation function
-        use_batchnorm: bool = (
-            False  # whether or not to use batch normalization after each dense layer
-        )
-        use_dropout: bool = True  # whether or not to use dropout after each dense layer
-        dropout_rate: float = 0.1  # the dropout rate
-        use_image_features: bool = True  # whether or not image features should be used as input
-        use_likes: bool = True  # whether or not 'likes' features should be used as input
-        l1_reg: float = 0.005  # L1 regularization coefficient
-        l2_reg: float = 0.005  # L2 regularization coefficient
-
-        # Whether or not a task-specific Embedding layer should be used on the 'likes' features.
-        # When set to 'True', it is expected that there no shared embedding is used.
-        embed_likes: bool = False
-
-    return TaskHyperParameters
-
-
-@pytest.fixture
-def HyperParameters(TaskHyperParameters):
-    from .testutils import TestSetup
-
-    @dataclass
-    class HyperParameters(TestSetup, Serializable):
-        """Hyperparameters of a multi-headed model."""
-
-        batch_size: int = 128  # the batch size
-        learning_rate: float = 0.001  # Learning Rate
-        optimizer: str = choice(
-            "SGD", "ADAM", default="SGD"
-        )  # Which optimizer to use during training.
-
-        # number of individual 'pages' that were kept during preprocessing of the 'likes'.
-        # This corresponds to the number of entries in the multi-hot like vector.
-        num_like_pages: int = 10_000
-
-        gender_loss_weight: float = 1.0  # relative weight of the gender loss
-        age_loss_weight: float = 1.0  # relative weight of the age_group loss
-
-        num_text_features: ClassVar[int] = 91
-        num_image_features: ClassVar[int] = 65
-
-        max_number_of_likes: int = 2000
-        embedding_dim: int = 8
-
-        shared_likes_embedding: bool = True
-
-        # Whether or not to better filtering of liked pages
-        use_custom_likes: bool = True
-
-        # Gender model settings
-        gender: TaskHyperParameters = TaskHyperParameters(
-            "gender",
-            num_layers=1,
-            num_units=32,
-            use_batchnorm=False,
-            use_dropout=True,
-            dropout_rate=0.1,
-            use_image_features=True,
-            use_likes=True,
-        )
-
-        # Age Group Model settings
-        age_group: TaskHyperParameters = TaskHyperParameters(
-            "age_group",
-            num_layers=2,
-            num_units=64,
-            use_batchnorm=False,
-            use_dropout=True,
-            dropout_rate=0.1,
-            use_image_features=True,
-            use_likes=True,
-        )
-
-        # Personality Model(s) settings:
-        personality: TaskHyperParameters = TaskHyperParameters(
-            "personality",
-            num_layers=1,
-            num_units=8,
-            use_batchnorm=False,
-            use_dropout=True,
-            dropout_rate=0.1,
-            use_image_features=False,
-            use_likes=False,
-        )
-
-    return HyperParameters

--- a/test/nesting/example_use_cases.py
+++ b/test/nesting/example_use_cases.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import ClassVar, List
 
+from simple_parsing.helpers.serialization.serializable import Serializable
+
 from ..test_utils import TestSetup
 
 __all__ = [
@@ -97,7 +99,7 @@ class TaskHyperParameters(TestSetup):
 
 
 @dataclass
-class HyperParameters(TestSetup):
+class HyperParameters(TestSetup, Serializable):
     """Hyperparameters of our model."""
 
     # the batch size

--- a/test/nesting/test_nesting_auto.py
+++ b/test/nesting/test_nesting_auto.py
@@ -1,8 +1,9 @@
 from simple_parsing import ConflictResolution
 
+from .example_use_cases import HyperParameters
 
-def test_real_use_case(silent, HyperParameters):
-    HyperParameters
+
+def test_real_use_case(silent):
     hparams = HyperParameters.setup(
         "--age_group.num_layers 5 " "--age_group.num_units 65 ",
         conflict_resolution_mode=ConflictResolution.AUTO,

--- a/test/nesting/test_nesting_explicit.py
+++ b/test/nesting/test_nesting_explicit.py
@@ -1,7 +1,9 @@
 from simple_parsing import ConflictResolution
 
+from .example_use_cases import HyperParameters, TaskHyperParameters
 
-def test_real_use_case(silent, HyperParameters, TaskHyperParameters):
+
+def test_real_use_case(silent):
     hparams = HyperParameters.setup(
         "--hyper_parameters.age_group.num_layers 5",
         conflict_resolution_mode=ConflictResolution.EXPLICIT,

--- a/test/nesting/test_nesting_merge.py
+++ b/test/nesting/test_nesting_merge.py
@@ -1,7 +1,9 @@
 from simple_parsing import ConflictResolution
 
+from .example_use_cases import HyperParameters
 
-def test_hparam_use_case(silent, HyperParameters, TaskHyperParameters):
+
+def test_hparam_use_case(silent):
     hparams = HyperParameters.setup(
         "--num_layers 5 6 7", conflict_resolution_mode=ConflictResolution.ALWAYS_MERGE
     )

--- a/test/nesting/test_weird_use_cases.py
+++ b/test/nesting/test_weird_use_cases.py
@@ -4,6 +4,8 @@ from typing import Callable, Type
 
 from simple_parsing import ConflictResolution
 
+from .example_use_cases import HyperParameters
+
 
 def simple_tree_structure(some_type: Type[T], default_value_function: Callable[[str], T]):
     @dataclass
@@ -200,7 +202,7 @@ def test_weird_with_duplicates_and_at_different_levels():
     assert aabbccdd.ccdd.dd.d2.d == "ccdd_dd_d_2"
 
 
-def test_defaults(HyperParameters):
+def test_defaults():
     default = HyperParameters()
     parsed = HyperParameters.setup("")
     for attr, value in vars(default).items():

--- a/test/test_custom_args.py
+++ b/test/test_custom_args.py
@@ -16,6 +16,7 @@ from .testutils import (
     raises_expected_n_args,
     raises_missing_required_arg,
     raises_unrecognized_args,
+    using_simple_api,
 )
 
 
@@ -182,27 +183,28 @@ def test_only_dashes():
         my_var: int
         a: AClass
 
-    assert_help_output_equals(
-        SomeClass.get_help_text(add_option_string_dash_variants=DashVariant.DASH),
-        textwrap.dedent(
-            """\
-            usage: pytest [-h] --my-var int --a-var int
+    if not using_simple_api():
+        assert_help_output_equals(
+            SomeClass.get_help_text(add_option_string_dash_variants=DashVariant.DASH),
+            textwrap.dedent(
+                """\
+                usage: pytest [-h] --my-var int --a-var int
 
-            optional arguments:
-              -h, --help    show this help message and exit
+                optional arguments:
+                -h, --help    show this help message and exit
 
-            test_only_dashes.<locals>.SomeClass ['some_class']:
-              lol
+                test_only_dashes.<locals>.SomeClass ['some_class']:
+                lol
 
-              --my-var int
+                --my-var int
 
-            test_only_dashes.<locals>.AClass ['some_class.a']:
-              foo
+                test_only_dashes.<locals>.AClass ['some_class.a']:
+                foo
 
-              --a-var int
-            """  # noqa: W293
-        ),
-    )
+                --a-var int
+                """  # noqa: W293
+            ),
+        )
     sc = SomeClass.setup("--my-var 2 --a-var 3", add_option_string_dash_variants=DashVariant.DASH)
     assert sc.my_var == 2
     assert sc.a.a_var == 3

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,4 +1,5 @@
 import enum
+import os
 from dataclasses import dataclass
 from typing import Dict, List, Set, Tuple, Type
 
@@ -100,9 +101,10 @@ def test_is_enum(t: Type):
     assert utils.is_enum(t)
 
 
-def test_json_serializable(HyperParameters, tmpdir):
+def test_json_serializable(tmpdir):
+    from .nesting.example_use_cases import HyperParameters
+
     hparams = HyperParameters()
-    import os
 
     filename = "hparams.json"
     hparams.save_json(os.path.join(tmpdir, filename))

--- a/test/utils/test_yaml.py
+++ b/test/utils/test_yaml.py
@@ -7,6 +7,8 @@ from typing import List
 from simple_parsing import list_field
 from simple_parsing.helpers.serialization import YamlSerializable
 
+from ..nesting.example_use_cases import HyperParameters
+
 
 @dataclass
 class Point(YamlSerializable):
@@ -63,7 +65,7 @@ def test_dumps_loads():
     )
 
 
-def test_save_yaml(HyperParameters, tmpdir: Path):
+def test_save_yaml(tmpdir: Path):
     hparams = HyperParameters.setup("")
     tmp_path = Path(tmpdir / "temp.yml")
     hparams.save_yaml(tmp_path)
@@ -72,7 +74,7 @@ def test_save_yaml(HyperParameters, tmpdir: Path):
     assert hparams == _hparams
 
 
-def test_save_json(HyperParameters, tmpdir: Path):
+def test_save_json(tmpdir: Path):
     hparams = HyperParameters.setup("")
     tmp_path = Path(tmpdir / "temp.json")
     hparams.save_yaml(tmp_path)
@@ -80,7 +82,7 @@ def test_save_json(HyperParameters, tmpdir: Path):
     assert hparams == _hparams
 
 
-def test_save_yml(HyperParameters, tmpdir: Path):
+def test_save_yml(tmpdir: Path):
     hparams = HyperParameters.setup("")
     tmp_path = Path(tmpdir / "temp.yml")
     hparams.save(tmp_path)


### PR DESCRIPTION
Fixes #163 

TODOs:
- [x] Figure out how prominently to show the `parse` api in the readme.
- [x] Add tests for the `parse` api (a LOT of them, if we make it the first thing people see in the readme)


Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>