### PR TITLE
Add `main` decorator for simple parsing of entry functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 typing_inspect;python_version<'3.9'
 typing_extensions
+docstring-parser~=0.15

--- a/simple_parsing/__init__.py
+++ b/simple_parsing/__init__.py
@@ -3,6 +3,7 @@
 """
 from . import helpers, utils, wrappers
 from .conflicts import ConflictResolution
+from .decorators import main
 from .help_formatter import SimpleHelpFormatter
 from .helpers import (
     MutableField,
@@ -27,28 +28,29 @@ from .parsing import (
 from .utils import InconsistentArgumentError
 
 __all__ = [
-    "helpers",
-    "utils",
-    "wrappers",
-    "ConflictResolution",
-    "SimpleHelpFormatter",
-    "MutableField",
-    "Serializable",
+    "ArgumentGenerationMode",
+    "ArgumentParser",
     "choice",
+    "ConflictResolution",
+    "DashVariant",
     "field",
     "flag",
+    "helpers",
+    "InconsistentArgumentError",
     "list_field",
+    "main",
     "mutable_field",
+    "MutableField",
+    "NestedMode",
+    "parse_known_args",
+    "parse",
+    "ParsingError",
+    "Serializable",
+    "SimpleHelpFormatter",
     "subgroups",
     "subparsers",
-    "ArgumentParser",
-    "DashVariant",
-    "ParsingError",
-    "parse",
-    "parse_known_args",
-    "ArgumentGenerationMode",
-    "NestedMode",
-    "InconsistentArgumentError",
+    "utils",
+    "wrappers",
 ]
 
 from . import _version

--- a/simple_parsing/decorators.py
+++ b/simple_parsing/decorators.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import collections
+import dataclasses
+import functools
+import inspect
+import typing
+from typing import Any, Callable, NamedTuple, Optional, Type, TypeVar
+
+import docstring_parser as dp
+from typing_extensions import ParamSpec
+
+from . import helpers, parsing
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class _Field(NamedTuple):
+    name: str
+    annotation: Type
+    field: dataclasses.Field
+
+
+def _description_from_docstring(docstring: dp.Docstring) -> str:
+    """Construct a description from the short and long description of a docstring."""
+    description = ""
+    if docstring.short_description:
+        description += f"{docstring.short_description}\n"
+        if docstring.blank_after_short_description:
+            description += "\n"
+    if docstring.long_description:
+        description += f"{docstring.long_description}\n"
+        if docstring.blank_after_long_description:
+            description += "\n"
+    return description
+
+
+def main(
+    original_function: Optional[Callable[P, T]] = None,
+    **sp_kwargs,
+) -> Callable[P, T]:
+    """Parse a function's arguments using simple-parsing from type annotations."""
+
+    def _decorate_with_cli_args(function: Callable[P, T]) -> Callable[P, T]:
+        """Decorate `function` by binding its arguments obtained from simple-parsing."""
+
+        @functools.wraps(function)
+        def _wrapper(*other_args: P.args, **other_kwargs: P.kwargs) -> T:
+            # Parse signature and parameters
+            signature = inspect.signature(function, follow_wrapped=True)
+            parameters = signature.parameters
+
+            # Parse docstring to use as help strings
+            docstring = dp.parse(inspect.getdoc(function) or "")
+            docstring_param_description = {
+                param.arg_name: param.description for param in docstring.params
+            }
+
+            # Parse all arguments from the function
+            fields = []
+            for name, parameter in parameters.items():
+                # Replace empty annotation with Any
+                if parameter.annotation == inspect.Parameter.empty:
+                    parameter = parameter.replace(annotation=Any)
+
+                # Parse default or default_factory if the default is callable.
+                default, default_factory = dataclasses.MISSING, dataclasses.MISSING
+                if parameter.default != inspect.Parameter.empty:
+                    if inspect.isfunction(parameter.default):
+                        default_factory = parameter.default
+                    else:
+                        default = parameter.default
+
+                field = _Field(
+                    name,
+                    parameter.annotation,
+                    helpers.field(
+                        name=name,
+                        default=default,
+                        default_factory=default_factory,
+                        help=docstring_param_description.get(name, ""),
+                        positional=parameter.kind == inspect.Parameter.POSITIONAL_ONLY,
+                    ),
+                )
+                fields.append(field)
+
+            # We can have positional arguments with no defaults that come out of order
+            # when parsing the function signature. Therefore, before we construct
+            # the dataclass we have to sort fields acording to their default value.
+            # We query fields by name so there's no need to worry about the order.
+            def _field_has_default(field: _Field) -> bool:
+                return (
+                    field.field.default is not dataclasses.MISSING
+                    or field.field.default_factory is not dataclasses.MISSING
+                )
+
+            fields = sorted(fields, key=_field_has_default)
+
+            # Create the dataclass using the fields derived from the function's signature
+            FunctionArgs = dataclasses.make_dataclass(function.__qualname__, fields)
+            FunctionArgs.__doc__ = _description_from_docstring(docstring) or None
+            function_args = parsing.parse(
+                FunctionArgs,
+                dest="args",
+                add_config_path_arg=False,
+                **sp_kwargs,
+            )
+
+            # Construct both positional and keyword arguments.
+            args, kwargs = [], {}
+            for field in dataclasses.fields(function_args):
+                value = getattr(function_args, field.name)
+                if field.metadata.get("positional", False):
+                    args.append(value)
+                else:
+                    # TODO: py39: use union operator (|=)
+                    kwargs.update({field.name: value})
+
+            # Construct positional arguments with CLI and runtime args
+            positionals = (*args, *other_args)
+            # Construct keyword arguments so it can override arguments
+            # so we don't receive multiple value errors.
+            keywords = collections.ChainMap(kwargs, other_kwargs)
+
+            # Call the function
+            return function(*positionals, **keywords)
+
+        return _wrapper
+
+    if original_function:
+        return _decorate_with_cli_args(original_function)
+
+    return _decorate_with_cli_args

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -225,6 +225,10 @@ class FieldWrapper(Wrapper[dataclasses.Field]):
         if not self.field.metadata.get("positional"):
             _arg_options["required"] = self.required
             _arg_options["dest"] = self.dest
+        elif not self.required:
+            # For positional arguments that aren't required we need to set
+            # nargs='?' to make them optional.
+            _arg_options["nargs"] = "?"
         _arg_options["default"] = self.default
         _arg_options["metavar"] = get_metavar(self.type)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os
+import pathlib
 import sys
 from logging import getLogger as get_logger
 from typing import Any, NamedTuple
@@ -146,3 +147,11 @@ def logs_warning(caplog):
     messages = [x.message for x in caplog.get_records("call") if x.levelno == logging.WARNING]
     if not messages:
         pytest.fail(f"No warning messages were logged: {messages}")
+
+
+def pytest_ignore_collect(collection_path: pathlib.Path):
+    # We can only test the decorator on Py38+.
+    # TODO: Remove this when we drop support for Py37
+    if sys.version_info < (3, 8) and collection_path.stem == "test_decorator":
+        return True
+    return False

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -1,0 +1,117 @@
+"""Tests simple parsing decorators.
+"""
+import collections
+import dataclasses
+import functools
+import inspect
+import typing
+from typing import Callable
+
+import pytest
+import simple_parsing as sp
+
+
+@dataclasses.dataclass
+class AddThreeNumbers:
+    a: int = 0
+    b: int = 0
+    c: int = 0
+
+    def __call__(self) -> int:
+        return self.a + self.b + self.c
+
+
+def _fn_with_positional_only(x: int, /) -> int:
+    return x
+
+
+def _fn_with_keyword_only(*, x: int) -> int:
+    return x
+
+
+def _fn_with_all_argument_types(a: int, /, b: int, *, c: int) -> int:
+    return a + b + c
+
+
+class ListWithPopDefault(collections.UserList):
+    def pop(self, index, default_value=None):
+        try:
+            return super().pop(index)
+        except IndexError:
+            return default_value
+
+
+def partial(fn: Callable, *args, **kwargs) -> Callable:
+    """Partial via changing the signature defaults."""
+
+    @functools.wraps(fn)
+    def _wrapper(*other_args, **other_kwargs):
+        return fn(*other_args, **other_kwargs)
+
+    signature = inspect.signature(fn)
+    parameters = signature.parameters
+
+    args = ListWithPopDefault(args)
+
+    new_parameters = []
+    for key, param in parameters.items():
+        param = typing.cast(inspect.Parameter, param)
+        default = args.pop(0, None) or kwargs.get(key, None)
+        if default is not None:
+            param = param.replace(default=default)
+        new_parameters.append(param)
+
+    signature = signature.replace(parameters=new_parameters)
+    _wrapper.__signature__ = signature
+
+    return _wrapper
+
+
+@pytest.mark.parametrize(
+    "args, expected, fn",
+    [
+        ("", 1, partial(_fn_with_positional_only, 1)),
+        ("2", 2, partial(_fn_with_positional_only, 1)),
+        ("2", 2, _fn_with_positional_only),
+        ("", 1, partial(_fn_with_keyword_only, x=1)),
+        ("--x=2", 2, partial(_fn_with_keyword_only, x=1)),
+        ("--x=2", 2, _fn_with_keyword_only),
+        ("", 3, partial(_fn_with_all_argument_types, 1, b=1, c=1)),
+        ("2", 4, partial(_fn_with_all_argument_types, b=1, c=1)),
+        ("2 --b=2", 5, partial(_fn_with_all_argument_types, c=1)),
+        ("2 --b=2 --c=2", 6, _fn_with_all_argument_types),
+        ("--c=2", 4, partial(_fn_with_all_argument_types, 1, b=1)),
+        ("--b=2", 4, partial(_fn_with_all_argument_types, 1, c=1)),
+        ("--b=2 --c=2", 5, partial(_fn_with_all_argument_types, 1)),
+    ],
+)
+def test_simple_arguments(
+    args: str,
+    expected: int,
+    fn: Callable,
+):
+    decorated = sp.decorators.main(fn, args=args)
+    assert decorated() == expected
+
+
+def _fn_with_nested_dataclass(x: int, /, *, data: AddThreeNumbers) -> int:
+    return x + data()
+
+
+@pytest.mark.parametrize(
+    "args, expected, fn",
+    [
+        ("", 1, partial(_fn_with_nested_dataclass, 1, data=AddThreeNumbers())),
+        ("--a=1", 2, partial(_fn_with_nested_dataclass, 1)),
+        ("--a=1 --b=1", 3, partial(_fn_with_nested_dataclass, 1)),
+        ("--a=1 --b=1 --c=1", 4, partial(_fn_with_nested_dataclass, 1)),
+        ("2 --a=1 --b=1 --c=1", 5, partial(_fn_with_nested_dataclass)),
+    ],
+)
+def test_nested_dataclass(
+    args: str,
+    expected: int,
+    fn: Callable,
+):
+    decorated = sp.decorators.main(fn, args=args)
+    assert decorated() == expected


### PR DESCRIPTION
Adds a decorator `main` that will parse command line arguments based on the type annotations of that function.

This decorator supports:
- Positional arguments via Python 3.8+'s support for positional-only arguments with the `/` syntax.
- Nested dataclasses as arguments to a function.
- Automatically parsing the help string based on the docstring of the function.


Example:

```py
import pathlib

import simple_parsing as sp

@sp.decorators.main
def mkdir(path: pathlib.Path, /, *, parents: bool = False, exist_ok: bool = False) -> None:
    """ Make a directory.
    
    Args:
        path: Path at which to create the directory.
        parents: Whether to create parent directories.
        exist_ok: If exist_ok is True `FileExistsError` will be raised.
    """
    path.mkdir(parents=parents, exist_ok=exist_ok)
    
if __name__ == '__main__':
    mkdir()
```