### PR TITLE
Modify forward_refs_to_types to fix issue #181

### DIFF
--- a/simple_parsing/annotation_utils/get_field_annotations.py
+++ b/simple_parsing/annotation_utils/get_field_annotations.py
@@ -6,7 +6,7 @@ import typing
 from contextlib import contextmanager
 from dataclasses import InitVar
 from logging import getLogger as get_logger
-from typing import Any, Dict, Iterator, Optional, get_type_hints
+from typing import Any, Dict, Iterator, Optional, get_type_hints, TypeVar
 
 logger = get_logger(__name__)
 
@@ -18,6 +18,7 @@ forward_refs_to_types = {
     "dict": typing.Dict,
     "list": typing.List,
     "type": typing.Type,
+    "D": TypeVar("D"),
 }
 
 

--- a/test/test_issue_181.py
+++ b/test/test_issue_181.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from simple_parsing import Serializable, ArgumentParser
+from dataclasses import dataclass
+import pytest
+
+@dataclass
+class MyArguments(Serializable):
+    arg1: str = 'this_argment'
+    
+@pytest.mark.parametrize(
+    'sys_argv, result', [
+        (['test.py'], 'this_argment'),
+        (['test.py', '--arg1', 'test2'], 'test2')
+    ],
+)
+def test_simple_parsing(sys_argv, result):
+    parser = ArgumentParser()
+    parser.add_arguments(MyArguments, 'myargs')
+    args, _ = parser.parse_known_args(sys_argv)
+    assert args.myargs.arg1 == result


### PR DESCRIPTION
The error was happend in ```get_field_type_from_annotations``` in get_field_annotations.py.

The comments under get_field_type_from_annotations said:
"NOTE: If you get errors of this kind from the function below, then you might want to add an entry to the `forward_refs_to_types` dict above."

I added ```{"D": TypeVar("D")"``` to the forward_refs_to_types. 
If add ```D = TypeVar("D", bound="SerializableMixin")``` to it, this will cause circle import error.

I also added a test_issue_181 for this issue #181 .

All tests have passed with this commit.
