### PR TITLE
Fix the `Dataclass` protocol and make it typing-only

### DIFF
--- a/simple_parsing/utils.py
+++ b/simple_parsing/utils.py
@@ -21,6 +21,7 @@ from logging import getLogger
 from typing import (
     Any,
     Callable,
+    ClassVar,
     Container,
     Dict,
     Iterable,
@@ -34,7 +35,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Literal, Protocol, TypeGuard, get_args, runtime_checkable, get_origin
+from typing_extensions import Literal, Protocol, TypeGuard, get_args, get_origin
 
 
 # NOTE: Copied from typing_inspect.
@@ -70,9 +71,8 @@ V = TypeVar("V")
 W = TypeVar("W")
 
 
-@runtime_checkable
 class Dataclass(Protocol):
-    __dataclass_fields__: dict[str, Field]
+    __dataclass_fields__: ClassVar[dict[str, Field]]
 
 
 def is_dataclass_instance(obj: Any) -> TypeGuard[Dataclass]:


### PR DESCRIPTION
- Fix the type of the `__dataclass_fields__` field on the `Dataclass` protocol.
- Make the Protocol typing-only (remove the possibility of using `isinstance` and `issubclass`). The reason for this is that there was no way to differentiate between a dataclass type, and a dataclass instance:
```python
@runtime_checkable
class Dataclass(Protocol):
    __dataclass_fields__: ClassVar[dict[str, Field]]

@dataclass
class Bob:
    a: int = 123

assert isinstance(Bob(), Dataclass) # fine
assert not isinstance(Bob, Dataclass)  # This shouldn't be True, but it is!
```
That's because it can't tell that `__dataclass_fields__` is an *instance* attribute on the class, and not a class variable!
Therefore I removed the `runtime_checkable` wrapper.

Signed-off-by: Fabrice Normandin <fabrice.normandin@gmail.com>