### PR TITLE
Mark annoying features with typing.deprecated

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-typing_extensions
 docstring-parser~=0.15
+typing_extensions>=4.5.0

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -14,6 +14,8 @@ from logging import getLogger
 from pathlib import Path
 from typing import Any, Callable, Sequence, TypeVar, overload
 
+from typing_extensions import Literal, deprecated
+
 from simple_parsing.wrappers.dataclass_wrapper import DataclassWrapperType
 
 from . import utils
@@ -174,6 +176,32 @@ class ArgumentParser(argparse.ArgumentParser):
     ) -> DataclassWrapper[DataclassT]:
         pass
 
+    @deprecated("Passing dict as default is deprecated and will be removed at some point.")
+    @overload
+    def add_arguments(
+        self,
+        dataclass: type[DataclassT],
+        dest: str,
+        *,
+        prefix: str = "",
+        default: dict = ...,
+        dataclass_wrapper_class: type[DataclassWrapper] = DataclassWrapper,
+    ) -> DataclassWrapper[DataclassT]:
+        pass
+
+    @deprecated("Support for passing 'argparse.SUPPRESS' might get deprecated and removed.")
+    @overload
+    def add_arguments(
+        self,
+        dataclass: type[DataclassT],
+        dest: str,
+        *,
+        prefix: str = "",
+        default: Literal["==SUPPRESS=="] | str = ...,
+        dataclass_wrapper_class: type[DataclassWrapper] = DataclassWrapper,
+    ) -> DataclassWrapper[DataclassT]:
+        pass
+
     @overload
     def add_arguments(
         self,
@@ -191,7 +219,7 @@ class ArgumentParser(argparse.ArgumentParser):
         dest: str,
         *,
         prefix: str = "",
-        default: DataclassT | None = None,
+        default: DataclassT | dict | str | None = None,
         dataclass_wrapper_class: type[DataclassWrapperType] = DataclassWrapper,
     ) -> DataclassWrapper[DataclassT] | DataclassWrapperType:
         """Adds command-line arguments for the fields of `dataclass`.

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -134,6 +134,7 @@ def test_running_example_outputs_expected_without_arg(
     set_prog_name: Callable[[str, str | None], None],
     assert_equals_stdout: Callable[[str, str], None],
 ):
+    # TODO: Use file_regression fixture to check output against a nicely formatted example script.
     return test_running_example_outputs_expected(file_path, "", set_prog_name, assert_equals_stdout)
 
 


### PR DESCRIPTION
I find some features annoying to support. I'd like to get rid of them or move them to a separate function.

Mark out the following features with [`typing.deprecated`](https://peps.python.org/pep-0702/):
- `parser.add_argument(dataclass, default=argparse.SUPPRESS)`
- `parser.add_argument(dataclass, default: dict)`
- (...) (more to come)
