### PR TITLE
fix postponed annotation when field is overwritten

### DIFF
--- a/test/postponed_annotations/overwrite_attribute.py
+++ b/test/postponed_annotations/overwrite_attribute.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ..test_utils import TestSetup
-from .overwrite_base import Base
+from .overwrite_base import Base, ParamCls
 
 
 @dataclass
-class ParamCls:
-    something_else: bool = True
+class ParamClsSubclass(ParamCls):
+    v: bool
 
 
 @dataclass
 class Subclass(Base, TestSetup):
-    other_attribute: ParamCls
+    attribute: ParamClsSubclass

--- a/test/postponed_annotations/overwrite_base.py
+++ b/test/postponed_annotations/overwrite_base.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass
 
 
 @dataclass
-class Foo:
+class ParamCls:
     ...
 
 
 @dataclass
 class Base:
-    a: Foo
+    attribute: ParamCls

--- a/test/postponed_annotations/test_postponed_annotations.py
+++ b/test/postponed_annotations/test_postponed_annotations.py
@@ -57,11 +57,27 @@ def test_postponed_annotations_with_multi_depth_inherits_2():
 
 
 def test_overwrite_base():
+    """Test that postponed annotations don't break types with the same name in multiple files."""
     import test.postponed_annotations.overwrite_base as overwrite_base
     import test.postponed_annotations.overwrite_subclass as overwrite_subclass
 
     assert overwrite_subclass.Subclass.setup(
         "--something_else False"
     ) == overwrite_subclass.Subclass(
-        a=overwrite_base.Foo(), other_attribute=overwrite_subclass.Foo(False)
+        attribute=overwrite_base.ParamCls(),
+        other_attribute=overwrite_subclass.ParamCls(False),
     )
+
+
+def test_overwrite_field():
+    """Test that postponed annotations don't break attribute overwriting in multiple files."""
+    import test.postponed_annotations.overwrite_base as overwrite_base
+    import test.postponed_annotations.overwrite_attribute as overwrite_attribute
+
+    instance = overwrite_attribute.Subclass.setup("--v True")
+    assert type(instance.attribute) != overwrite_base.ParamCls, (
+        "attribute type from Base class correctly ignored"
+    )
+    assert instance == overwrite_attribute.Subclass(
+        attribute=overwrite_attribute.ParamClsSubclass(True)
+    ), "parsed attribute value is correct"


### PR DESCRIPTION
Thanks to @zhiruiluo #183 covers the main problem described in #168.
However, I want to cover one more case when subclass definition overwrites variable type with specific subtype.