### PR TITLE
Proper support for subgroups in yaml configs

### DIFF
--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -74,6 +74,13 @@ def decode_field(field: Field, raw_value: Any, containing_dataclass: type | None
     """
     name = field.name
     field_type = field.type
+    
+    subgroup_info = field.metadata.get("subgroups")
+    if subgroup_info is not None:
+        subgroup = raw_value.pop("__subgroup__", None)
+        if subgroup:
+            field_type = subgroup_info[subgroup]
+
     logger.debug(f"name = {name}, field_type = {field_type}")
 
     # If the user set a custom decoding function, we use it.

--- a/simple_parsing/helpers/serialization/serializable.py
+++ b/simple_parsing/helpers/serialization/serializable.py
@@ -680,6 +680,22 @@ def to_dict(dc, dict_factory: type[dict] = dict, recurse: bool = True) -> dict:
             except TypeError:
                 encoded = to_dict(value)
             logger.debug(f"Encoded dataclass field {name}: {encoded}")
+
+            # If the field is a subgroup, we need to figure out which subgroup it is,
+            # and save that string in the dict.
+            subgroup_info = f.metadata.get("subgroups")
+            if subgroup_info:
+                # Invert the subgroup_info dict to get a mapping from subgroup type to subgroup name.
+                subgroup_type_to_name = {v: k for k, v in subgroup_info.items()}
+                subgroup_type = type(value)
+                if subgroup_type not in subgroup_type_to_name:
+                    raise ValueError(
+                        f"Subgroup type {subgroup_type} not found in subgroup_info dict: {subgroup_info}"
+                    )
+
+                # Save the subgroup name in the dict.
+                subgroup_name = subgroup_type_to_name[subgroup_type]
+                encoded["__subgroup__"] = subgroup_name
         else:
             try:
                 encoded = encoding_fn(value)

--- a/test/test_decoding.py
+++ b/test/test_decoding.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 import pytest
 
-from simple_parsing.helpers import Serializable, dict_field, list_field
+from simple_parsing.helpers import Serializable, dict_field, list_field, subgroups
 from simple_parsing.helpers.serialization.decoding import get_decoding_fn
 
 
@@ -76,6 +76,32 @@ def test_typevar_decoding(simple_attribute):
     #     "hey4": expected_value,
     # })
     assert SomeClass.loads(b.dumps()) == b
+
+
+def test_subgroups():
+    @dataclass
+    class InnerABC(Serializable):
+        x: list = list_field()
+
+    @dataclass
+    class Inner1(InnerABC):
+        y2: list = list_field()
+    
+    @dataclass
+    class Inner2(InnerABC):
+        y2: list = list_field()
+
+    @dataclass
+    class Outer(Serializable):
+        inner: InnerABC = subgroups(
+            {"inner1": Inner1, "inner2": Inner2},
+            default="inner1"
+        )
+
+    outer1 = Outer(inner=Inner1(x=[1, 2, 3], y2=[4, 5, 6]))
+    outer2 = Outer(inner=Inner2(x=[1, 2, 3], y2=[4, 5, 6]))
+    assert Outer.loads(outer1.dumps()) == outer1
+    assert Outer.loads(outer2.dumps()) == outer2
 
 
 def test_super_nesting():

--- a/test/test_decoding.py
+++ b/test/test_decoding.py
@@ -85,7 +85,7 @@ def test_subgroups():
 
     @dataclass
     class Inner1(InnerABC):
-        y2: list = list_field()
+        y1: list = list_field()
     
     @dataclass
     class Inner2(InnerABC):
@@ -98,10 +98,14 @@ def test_subgroups():
             default="inner1"
         )
 
-    outer1 = Outer(inner=Inner1(x=[1, 2, 3], y2=[4, 5, 6]))
+    outer1 = Outer(inner=Inner1(x=[1, 2, 3], y1=[4, 5, 6]))
     outer2 = Outer(inner=Inner2(x=[1, 2, 3], y2=[4, 5, 6]))
     assert Outer.loads(outer1.dumps()) == outer1
     assert Outer.loads(outer2.dumps()) == outer2
+
+    # Should be using the __subgroup__ field to encode the type of the inner class
+    assert "__subgroup__" in outer1.dumps()
+    assert "__subgroup__" in outer2.dumps()
 
 
 def test_super_nesting():


### PR DESCRIPTION
Fixes #173.

For subgroup fields, a `__subgroup__` entry is added inside the yaml file whose value is the name of the subgroup that was selected. This is used upon loading to select the appropriate class to instantiate.

Probably some tests need to be added for this; will look at doing this ASAP