### PR TITLE
Make it possible to overwrite a decoding fn for a given type

### DIFF
--- a/simple_parsing/helpers/serialization/decoding.py
+++ b/simple_parsing/helpers/serialization/decoding.py
@@ -222,15 +222,17 @@ def get_decoding_fn(type_annotation: type[T] | str) -> Callable[..., T]:
     return try_constructor(t)
 
 
-def _register(t: type, func: Callable) -> None:
-    if t not in _decoding_fns:
+def _register(t: type, func: Callable, overwrite: bool = False) -> None:
+    if t not in _decoding_fns or overwrite:
         # logger.debug(f"Registering the type {t} with decoding function {func}")
         _decoding_fns[t] = func
 
 
-def register_decoding_fn(some_type: type[T], function: Callable[[Any], T]) -> None:
+def register_decoding_fn(
+    some_type: type[T], function: Callable[[Any], T], overwrite: bool = False
+) -> None:
     """Register a decoding function for the type `some_type`."""
-    _register(some_type, function)
+    _register(some_type, function, overwrite=overwrite)
 
 
 def decode_optional(t: type[T]) -> Callable[[Any | None], T | None]:

--- a/test/test_decoding.py
+++ b/test/test_decoding.py
@@ -160,6 +160,20 @@ def test_registering_safe_casting_decoding_fn():
 
     register_decoding_fn(int, _safe_cast, overwrite=True)
 
+    assert (
+        Parameters.loads_yaml(
+            textwrap.dedent(
+                """\
+        hparams:
+            use_log: 1
+            severity: 0.0
+            probs: [3, 4.0]
+        """
+            )
+        )
+        == Parameters(hparams=Hparams(severity=0, probs=[3, 4]))
+    )
+
     with pytest.raises(ValueError, match="Cannot safely cast 0.1 to int"):
         Parameters.loads_yaml(
             textwrap.dedent(
@@ -187,6 +201,7 @@ def test_registering_safe_casting_decoding_fn():
     register_decoding_fn(int, int, overwrite=True)
 
 
+@pytest.mark.xfail(strict=True, match="DID NOT RAISE <class 'ValueError'>")
 def test_optional_list_type_doesnt_use_type_decoding_fn():
     """BUG: Parsing an Optional[list[int]] doesn't work correctly."""
 
@@ -205,6 +220,7 @@ def test_optional_list_type_doesnt_use_type_decoding_fn():
     with pytest.raises(ValueError):
         get_decoding_fn(List[int])([0.1, 0.2])
 
+    # BUG: This doesn't work correctly.
     with pytest.raises(ValueError):
         get_decoding_fn(Optional[List[int]])([0.1, 0.2])
 

--- a/test/test_decoding.py
+++ b/test/test_decoding.py
@@ -1,12 +1,17 @@
 import json
-from dataclasses import dataclass
+import textwrap
+from dataclasses import dataclass, field
+from pathlib import Path
 from test.testutils import Generic, TypeVar
 from typing import Any, Dict, List, Optional, Tuple, Type
 
 import pytest
 
 from simple_parsing.helpers import Serializable, dict_field, list_field
-from simple_parsing.helpers.serialization.decoding import get_decoding_fn
+from simple_parsing.helpers.serialization.decoding import (
+    get_decoding_fn,
+    register_decoding_fn,
+)
 
 
 def test_encode_something(simple_attribute):
@@ -104,3 +109,103 @@ def test_decode_tuple(some_type: Type, encoded_value: Any, expected_value: Any):
     decoding_function = get_decoding_fn(some_type)
     actual = decoding_function(encoded_value)
     assert actual == expected_value
+
+
+@dataclass
+class Hparams:
+    use_log: int = 1
+    severity: int = 2
+    probs: List[int] = field(default_factory=lambda: [1, 2])
+
+
+@dataclass
+class Parameters(Serializable):
+    hparams: Hparams = field(default_factory=Hparams)
+
+
+def test_implicit_int_casting(tmp_path: Path):
+    """Test for 'issue' #227: https://github.com/lebrice/SimpleParsing/issues/227"""
+
+    with open(tmp_path / "conf.yaml", "w") as f:
+        f.write(
+            textwrap.dedent(
+                """\
+                hparams:
+                    use_log: 1
+                    severity: 0.1
+                    probs: [0.1, 0.2]
+                """
+            )
+        )
+
+    file_config = Parameters.load(tmp_path / "conf.yaml")
+    assert file_config == Parameters(hparams=Hparams(severity=0, probs=[0, 0]))
+
+
+def test_registering_safe_casting_decoding_fn():
+    """Test the solution to 'issue' #227: https://github.com/lebrice/SimpleParsing/issues/227"""
+
+    # Solution: register a decoding function for `int` that casts to int, but raises an error if
+    # the value would lose precision.
+
+    # Do this so the parsing function for `List[int]` is rebuilt to use the new parsing function
+    # for `int`.
+    get_decoding_fn.cache_clear()
+
+    def _safe_cast(v: Any) -> int:
+        int_v = int(v)
+        if int_v != float(v):
+            raise ValueError(f"Cannot safely cast {v} to int")
+        return int_v
+
+    register_decoding_fn(int, _safe_cast, overwrite=True)
+
+    with pytest.raises(ValueError, match="Cannot safely cast 0.1 to int"):
+        Parameters.loads_yaml(
+            textwrap.dedent(
+                """\
+            hparams:
+                use_log: 1
+                severity: 0.1
+                probs: [0, 0]
+            """
+            )
+        )
+
+    with pytest.raises(ValueError, match="Cannot safely cast 0.2 to int"):
+        Parameters.loads_yaml(
+            textwrap.dedent(
+                """\
+            hparams:
+                use_log: 1
+                severity: 1
+                probs: [0.2, 0.3]
+            """
+            )
+        )
+
+    register_decoding_fn(int, int, overwrite=True)
+
+
+def test_optional_list_type_doesnt_use_type_decoding_fn():
+    """BUG: Parsing an Optional[list[int]] doesn't work correctly."""
+
+    # Do this so the parsing function for `List[int]` is rebuilt to use the new parsing function
+    # for `int`.
+    get_decoding_fn.cache_clear()
+
+    def _safe_cast(v: Any) -> int:
+        int_v = int(v)
+        if int_v != float(v):
+            raise ValueError(f"Cannot safely cast {v} to int")
+        return int_v
+
+    register_decoding_fn(int, _safe_cast, overwrite=True)
+
+    with pytest.raises(ValueError):
+        get_decoding_fn(List[int])([0.1, 0.2])
+
+    with pytest.raises(ValueError):
+        get_decoding_fn(Optional[List[int]])([0.1, 0.2])
+
+    register_decoding_fn(int, int, overwrite=True)


### PR DESCRIPTION
Makes the user-side fix for #227 possible.