### PR TITLE
Simplify and Fix test_decorator.py

### DIFF
--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -44,27 +44,8 @@ class ListWithPopDefault(collections.UserList):
 
 
 def partial(fn: Callable, *args, **kwargs) -> Callable:
-    """Partial via changing the signature defaults."""
-
-    @functools.wraps(fn)
-    def _wrapper(*other_args, **other_kwargs):
-        return fn(*other_args, **other_kwargs)
-
-    signature = inspect.signature(fn)
-    parameters = signature.parameters
-
-    args = ListWithPopDefault(args)
-
-    new_parameters = []
-    for key, param in parameters.items():
-        param = typing.cast(inspect.Parameter, param)
-        default = args.pop(0, None) or kwargs.get(key, None)
-        if default is not None:
-            param = param.replace(default=default)
-        new_parameters.append(param)
-
-    signature = signature.replace(parameters=new_parameters)
-    _wrapper.__signature__ = signature
+    _wrapper = functools.partial(fn, *args, **kwargs)
+    _wrapper.__qualname__ = fn.__qualname__
 
     return _wrapper
 
@@ -73,7 +54,7 @@ def partial(fn: Callable, *args, **kwargs) -> Callable:
     "args, expected, fn",
     [
         ("", 1, partial(_fn_with_positional_only, 1)),
-        ("2", 2, partial(_fn_with_positional_only, 1)),
+        ("2", 2, partial(_fn_with_positional_only)),
         ("2", 2, _fn_with_positional_only),
         ("", 1, partial(_fn_with_keyword_only, x=1)),
         ("--x=2", 2, partial(_fn_with_keyword_only, x=1)),

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -43,7 +43,8 @@ class ListWithPopDefault(collections.UserList):
 
 def delay_evaluation_wrapper(fn: Callable) -> Callable:
     def delayed_call(*args, **kwargs):
-        return lambda : fn(*args, **kwargs)
+        return lambda: fn(*args, **kwargs)
+
     return delayed_call
 
 
@@ -115,9 +116,6 @@ def test_simple_arguments(
 
 def _fn_with_nested_dataclass(x: int, /, *, data: AddThreeNumbers) -> int:
     return x + data()
-
-
-
 
 
 @pytest.mark.parametrize(

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -32,14 +32,6 @@ def _fn_with_all_argument_types(a: int, /, b: int, *, c: int) -> int:
     return a + b + c
 
 
-class ListWithPopDefault(collections.UserList):
-    def pop(self, index, default_value=None):
-        try:
-            return super().pop(index)
-        except IndexError:
-            return default_value
-
-
 def partial(fn: Callable, *args, **kwargs) -> Callable:
     _wrapper = functools.partial(fn, *args, **kwargs)
     _wrapper.__qualname__ = fn.__qualname__

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -1,11 +1,8 @@
-"""Tests simple parsing decorators.
-"""
+"""Tests simple parsing decorators."""
 import collections
 import dataclasses
 import functools
-import inspect
 import sys
-import typing
 from typing import Callable
 
 import pytest


### PR DESCRIPTION
- Based on #270  
- Renames `partial` to `change_defaults` to clarify the test file a bit.
- Remove the `delay_wrapper`, replace it with `functools.partial`
- Add an `if` in the test file to only use the additional level of indirection when needed.

Fixes #269

