### PR TITLE
Add support for TOML config files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ extras_require: dict[str, list[str]] = {
         # "torch",
     ],
     "yaml": ["pyyaml"],
+    "toml": ["tomli", "tomli_w"],
 }
 extras_require["all"] = list(set(sum(extras_require.values(), [])))
 

--- a/simple_parsing/helpers/serialization/serializable.py
+++ b/simple_parsing/helpers/serialization/serializable.py
@@ -125,6 +125,20 @@ class TorchExtension(FormatExtension):
         return torch.save(obj, io, **kwargs)
 
 
+class TOMLExtension(FormatExtension):
+    binary: bool = True
+
+    def load(self, io: IO) -> Any:
+        import tomli
+
+        return tomli.load(io)
+
+    def dump(self, obj: Any, io: IO, **kwargs) -> None:
+        import tomli_w
+
+        return tomli_w.dump(obj, io, **kwargs)
+
+
 json_extension = JSONExtension()
 yaml_extension = YamlExtension()
 
@@ -136,6 +150,7 @@ extensions: dict[str, FormatExtension] = {
     ".yml": YamlExtension(),
     ".npy": NumpyExtension(),
     ".pth": TorchExtension(),
+    ".toml": TOMLExtension(),
 }
 
 

--- a/test/helpers/test_save.py
+++ b/test/helpers/test_save.py
@@ -63,3 +63,12 @@ def test_save_torch(tmpdir: Path):
 
     _hparams = HyperParameters.load(tmp_path)
     assert hparams == _hparams
+
+
+def test_save_toml(tmpdir: Path):
+    hparams = HyperParameters.setup("")
+    tmp_path = Path(tmpdir / "temp.toml")
+    hparams.save(tmp_path)
+
+    _hparams = HyperParameters.load(tmp_path)
+    assert hparams == _hparams


### PR DESCRIPTION
It'd be nice to support configs in the TOML format in addition to all the other formats that are supported already. 

This PR adds the the depedencies for `tomli` and `tomli-w` as extras, creates a new `FormatExtension` and a small unit test. I've only tested this so far by running the unit test and checking that the created TOML file looks reasonable.