### PR TITLE
Union handles lists

### DIFF
--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -330,6 +330,8 @@ class FieldWrapper(Wrapper):
         elif self.is_union:
             logger.debug("Parsing a Union type!")
             _arg_options["type"] = get_parsing_fn(self.type)
+            if any(utils.is_list(o) for o in utils.get_args(self.type)):
+                _arg_options["nargs"] = "*"
 
         elif self.is_enum:
             logger.debug(f"Adding an Enum attribute '{self.name}'")
@@ -500,6 +502,13 @@ class FieldWrapper(Wrapper):
                 return list(raw_parsed_value)
             else:
                 return raw_parsed_value
+
+        elif self.is_union:
+            list_in = [utils.is_list(o) for o in utils.get_args(self.type)]
+            # if type is like Union[str, list[str]] and only a single value was passed,
+            if any(list_in) and (not all(list_in)) and (len(raw_parsed_value) == 1):
+                raw_parsed_value = raw_parsed_value[0]
+            return raw_parsed_value
 
         elif self.is_subparser:
             return raw_parsed_value

--- a/test/test_union.py
+++ b/test/test_union.py
@@ -35,7 +35,6 @@ def test_union_type_raises_error():
 
 
 def test_union_type_with_list():
-
     @dataclass
     class Foo(TestSetup):
         x: Union[str, list[str]]

--- a/test/test_union.py
+++ b/test/test_union.py
@@ -32,3 +32,26 @@ def test_union_type_raises_error():
 
     foo = Foo2.setup("--x 2")
     assert foo.x == 2 and type(foo.x) is int
+
+
+def test_union_type_with_list():
+
+    @dataclass
+    class Foo(TestSetup):
+        x: Union[str, list[str]]
+
+    foo = Foo.setup("--x bob")
+    assert foo.x == "bob"
+
+    foo = Foo.setup("--x bob alice")
+    assert foo.x == ["bob", "alice"]
+
+    @dataclass
+    class Foo(TestSetup):
+        x: Union[list[int], list[str]]
+
+    foo = Foo.setup("--x bob alice")
+    assert foo.x == ["bob", "alice"]
+
+    foo = Foo.setup("--x 1 2")
+    assert foo.x == [1, 2]


### PR DESCRIPTION
For #297

There might be a more elegant way to handle this but I think it would require redoing a lot more than this?

I also am not sure if this is the correct place to put this as there seemed like 2-3 other potential places and maybe more if i kept looking.

The if/else stuff is basically just trying to handle the equivalent of below (which probably makes more sense if there are more cases  to worry about for UnionTypes):

```python

  if any(utils.is_list(o) for o in utils.get_args(self.type)):
      # for: Union[list[int], list[str]] keep as list
      if all(utils.is_list(o) for o in utils.get_args(self.type)):
          return raw_parsed_value
      # for Union[str, list[str]] if single value, then dont keep as list
      elif len(raw_parsed_value) == 1:
          return raw_parsed_value[0]
  # are there other cases?
```