### PR TITLE
Try to use stdlib tomllib before tomli

### DIFF
--- a/simple_parsing/helpers/serialization/serializable.py
+++ b/simple_parsing/helpers/serialization/serializable.py
@@ -129,9 +129,12 @@ class TOMLExtension(FormatExtension):
     binary: bool = True
 
     def load(self, io: IO) -> Any:
-        import tomli
+        try:
+            import tomllib
+        except ImportError:
+            import tomli as tomllib
 
-        return tomli.load(io)
+        return tomllib.load(io)
 
     def dump(self, obj: Any, io: IO, **kwargs) -> None:
         import tomli_w


### PR DESCRIPTION
Since Python 3.11, the standard library comes with a [TOML parser](https://docs.python.org/3/library/tomllib.html#module-tomllib). 