### PR TITLE
Fix #307: Replace logger.info with logger.debug

### DIFF
--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -829,10 +829,10 @@ class ArgumentParser(argparse.ArgumentParser):
         assert len(sorted_dc_wrappers) == len(set(sorted_dc_wrappers))
 
         for dc_wrapper in sorted_dc_wrappers:
-            logger.info(f"Instantiating the wrapper with destinations {dc_wrapper.destinations}")
+            logger.debug(f"Instantiating the wrapper with destinations {dc_wrapper.destinations}")
 
             for destination in dc_wrapper.destinations:
-                logger.info(f"Instantiating the dataclass at destination {destination}")
+                logger.debug(f"Instantiating the dataclass at destination {destination}")
                 # Instantiate the dataclass by passing the constructor arguments
                 # to the constructor.
                 constructor = dc_wrapper.dataclass_fn

--- a/simple_parsing/wrappers/dataclass_wrapper.py
+++ b/simple_parsing/wrappers/dataclass_wrapper.py
@@ -208,7 +208,7 @@ class DataclassWrapper(Wrapper, Generic[DataclassT]):
                     f"--help text."
                 )
 
-            logger.info(f"group.add_argument(*{wrapped_field.option_strings}, **{arg_options})")
+            logger.debug(f"group.add_argument(*{wrapped_field.option_strings}, **{arg_options})")
             # TODO: Perhaps we could hook into the `action` that is returned here to know if the
             # flag was passed or not for a given field.
             _ = group.add_argument(*wrapped_field.option_strings, **arg_options)

--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -225,7 +225,7 @@ class FieldWrapper(Wrapper):
                     # string, and the values are always dataclass types. We don't need to worry
                     # about having to deal with {"bob": "alice", "alice": "foo"}-type weirdness.
                     namespace.subgroups[self.dest] = value
-                    logger.info(f"Chosen subgroup for '{self.dest}':  '{value}'")
+                    logger.debug(f"Chosen subgroup for '{self.dest}':  '{value}'")
 
     def get_arg_options(self) -> dict[str, Any]:
         """Create the `parser.add_arguments` kwargs for this field.


### PR DESCRIPTION
Lower the verbosity level of several log statements in the `parse_args` method of the `ArgumentParser` class and related classes to DEBUG level. This change ensures that less critical information about instantiating wrappers and dataclasses is logged only when debugging, preventing unnecessary output during regular usage. 