### PR TITLE
Add option to specify config path argument name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
 
   # md formatting
   - repo: https://github.com/executablebooks/mdformat
-    rev: 0.7.16
+    rev: 0.7.21
     hooks:
       - id: mdformat
         args: ["--number"]

--- a/examples/config_files/one_config.py
+++ b/examples/config_files/one_config.py
@@ -13,7 +13,7 @@ class TrainConfig:
 
 
 def main(args=None) -> None:
-    cfg = simple_parsing.parse(config_class=TrainConfig, args=args, add_config_path_arg=True)
+    cfg = simple_parsing.parse(config_class=TrainConfig, args=args, add_config_path_arg="config_file")
     print(f"Training {cfg.exp_name} with {cfg.workers} workers...")
 
 
@@ -28,7 +28,7 @@ Training default_exp with 8 workers...
 """
 
 # NOTE: When running as in the readme:
-main("--config_path one_config.yaml --exp_name my_first_exp")
+main("--config_file one_config.yaml --exp_name my_first_exp")
 expected += """\
 Training my_first_exp with 42 workers...
 """

--- a/examples/config_files/one_config.py
+++ b/examples/config_files/one_config.py
@@ -14,7 +14,7 @@ class TrainConfig:
 
 def main(args=None) -> None:
     cfg = simple_parsing.parse(
-        config_class=TrainConfig, args=args, add_config_path_arg="config_file"
+        config_class=TrainConfig, args=args, add_config_path_arg="config-file"
     )
     print(f"Training {cfg.exp_name} with {cfg.workers} workers...")
 
@@ -30,7 +30,7 @@ Training default_exp with 8 workers...
 """
 
 # NOTE: When running as in the readme:
-main("--config_file one_config.yaml --exp_name my_first_exp")
+main("--config-file one_config.yaml --exp_name my_first_exp")
 expected += """\
 Training my_first_exp with 42 workers...
 """

--- a/examples/config_files/one_config.py
+++ b/examples/config_files/one_config.py
@@ -13,7 +13,9 @@ class TrainConfig:
 
 
 def main(args=None) -> None:
-    cfg = simple_parsing.parse(config_class=TrainConfig, args=args, add_config_path_arg="config_file")
+    cfg = simple_parsing.parse(
+        config_class=TrainConfig, args=args, add_config_path_arg="config_file"
+    )
     print(f"Training {cfg.exp_name} with {cfg.workers} workers...")
 
 

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -166,11 +166,6 @@ class ArgumentParser(argparse.ArgumentParser):
         if add_config_path_arg is None:
             # By default, add a config path argument if a config path was passed.
             add_config_path_arg = bool(config_path)
-        if isinstance(add_config_path_arg, str) and not add_config_path_arg.isidentifier():
-            raise ValueError(
-                "If `add_config_path_arg` is a string it must be a valid Python identifier (no dashes)."
-                f" Not: {add_config_path_arg}"
-            )
         self.add_config_path_arg = add_config_path_arg
 
     # TODO: Remove, since the base class already has nicer type hints.
@@ -330,7 +325,7 @@ class ArgumentParser(argparse.ArgumentParser):
                 help="Path to a config file containing default values to use.",
             )
             args_with_config_path, args = temp_parser.parse_known_args(args)
-            config_path = getattr(args_with_config_path, config_path_name)
+            config_path = getattr(args_with_config_path, config_path_name.replace("-", "_"))
 
             if config_path is not None:
                 config_paths = config_path if isinstance(config_path, list) else [config_path]
@@ -1028,7 +1023,7 @@ def parse(
     If `config_path` is passed, loads the values from that file and uses them as defaults.
     """
     if dest == add_config_path_arg:
-        raise ValueError("`add_config_path_arg` cannot use the same name as `dest`.")
+        raise ValueError("`add_config_path_arg` cannot be the same as `dest`.")
 
     parser = ArgumentParser(
         nested_mode=nested_mode,

--- a/simple_parsing/parsing.py
+++ b/simple_parsing/parsing.py
@@ -100,7 +100,7 @@ class ArgumentParser(argparse.ArgumentParser):
     - add_config_path_arg : bool, str, optional
         When set to `True`, adds a `--config_path` argument, of type Path, which is used to parse.
         If set to a string then this is the name of the config_path argument.
-        
+
     - config_path: str, optional
         The values read from this file will overwrite the default values from the dataclass definitions.
         When `add_config_path_arg` is also set the defaults are first updated using `config_path`, and then
@@ -167,8 +167,10 @@ class ArgumentParser(argparse.ArgumentParser):
             # By default, add a config path argument if a config path was passed.
             add_config_path_arg = bool(config_path)
         if isinstance(add_config_path_arg, str) and not add_config_path_arg.isidentifier():
-            raise ValueError("If `add_config_path_arg` is a string it must be a valid Python identifier (no dashes)."
-                             f" Not: {add_config_path_arg}")
+            raise ValueError(
+                "If `add_config_path_arg` is a string it must be a valid Python identifier (no dashes)."
+                f" Not: {add_config_path_arg}"
+            )
         self.add_config_path_arg = add_config_path_arg
 
     # TODO: Remove, since the base class already has nicer type hints.
@@ -308,7 +310,11 @@ class ArgumentParser(argparse.ArgumentParser):
                 self.set_defaults(config_file)
 
         if self.add_config_path_arg:
-            config_path_name = self.add_config_path_arg if isinstance(self.add_config_path_arg, str) else 'config_path'
+            config_path_name = (
+                self.add_config_path_arg
+                if isinstance(self.add_config_path_arg, str)
+                else "config_path"
+            )
             temp_parser = ArgumentParser(
                 add_config_path_arg=False,
                 add_help=False,
@@ -1023,7 +1029,7 @@ def parse(
     """
     if dest == add_config_path_arg:
         raise ValueError("`add_config_path_arg` cannot use the same name as `dest`.")
-    
+
     parser = ArgumentParser(
         nested_mode=nested_mode,
         add_help=True,

--- a/test/test_conf_path.py
+++ b/test/test_conf_path.py
@@ -15,9 +15,9 @@ class BarConf:
 
 
 @pytest.mark.parametrize(
-    "invalid_value", ["config-file", "config_file", "foo.bar.baz?", "bob bob bob"]
+    "conf_arg_name", ["config-file", "config_file", "foo.bar.baz?", "bob bob bob"]
 )
-def test_config_path_arg(tmp_path: Path, invalid_value: str):
+def test_config_path_arg(tmp_path: Path, conf_arg_name: str):
     """Test config_path with valid strings."""
     # Create config file
     conf_path = tmp_path / "foo.yml"
@@ -25,27 +25,27 @@ def test_config_path_arg(tmp_path: Path, invalid_value: str):
         json.dump({"foo": "bee"}, f)
 
     # with pytest.raises(ValueError):
-    parser = ArgumentParser(BarConf, add_config_path_arg=invalid_value)
-    args = parser.parse_args([f"--{invalid_value}", str(conf_path)])
+    parser = ArgumentParser(BarConf, add_config_path_arg=conf_arg_name)
+    args = parser.parse_args([f"--{conf_arg_name}", str(conf_path)])
     print(args)
 
 
 @pytest.mark.parametrize(
-    "invalid_value",
+    "conf_arg_name",
     [
         "-------",
     ],
 )
-def test_pass_invalid_value_to_add_config_path_arg(tmp_path: Path, invalid_value: str):
+def test_pass_invalid_value_to_add_config_path_arg(tmp_path: Path, conf_arg_name: str):
     """Test config_path with invalid strings."""
     # Create config file
     conf_path = tmp_path / "foo.yml"
     with conf_path.open("w") as f:
         json.dump({"foo": "bee"}, f)
 
-    parser = ArgumentParser(BarConf, add_config_path_arg=invalid_value)
+    parser = ArgumentParser(BarConf, add_config_path_arg=conf_arg_name)
     with pytest.raises(ValueError):
-        parser.parse_args([f"--{invalid_value}", str(conf_path)])
+        parser.parse_args([f"--{conf_arg_name}", str(conf_path)])
 
 
 def test_config_path_same_as_dst_error():

--- a/test/test_conf_path.py
+++ b/test/test_conf_path.py
@@ -1,0 +1,54 @@
+"""Tests for config-path option."""
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from simple_parsing.parsing import ArgumentParser, parse
+
+
+@dataclass
+class BarConf:
+    foo: str
+
+
+@pytest.mark.parametrize(
+    "invalid_value", ["config-file", "config_file", "foo.bar.baz?", "bob bob bob"]
+)
+def test_config_path_arg(tmp_path: Path, invalid_value: str):
+    """Test config_path with valid strings."""
+    # Create config file
+    conf_path = tmp_path / "foo.yml"
+    with conf_path.open("w") as f:
+        json.dump({"foo": "bee"}, f)
+
+    # with pytest.raises(ValueError):
+    parser = ArgumentParser(BarConf, add_config_path_arg=invalid_value)
+    args = parser.parse_args([f"--{invalid_value}", str(conf_path)])
+    print(args)
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        "-------",
+    ],
+)
+def test_pass_invalid_value_to_add_config_path_arg(tmp_path: Path, invalid_value: str):
+    """Test config_path with invalid strings."""
+    # Create config file
+    conf_path = tmp_path / "foo.yml"
+    with conf_path.open("w") as f:
+        json.dump({"foo": "bee"}, f)
+
+    parser = ArgumentParser(BarConf, add_config_path_arg=invalid_value)
+    with pytest.raises(ValueError):
+        parser.parse_args([f"--{invalid_value}", str(conf_path)])
+
+
+def test_config_path_same_as_dst_error():
+    """Raise an error if add_config_path_arg and dest are the equal."""
+    with pytest.raises(ValueError, match="`add_config_path_arg` cannot be the same as `dest`."):
+        parse(BarConf, dest="boo", add_config_path_arg="boo")


### PR DESCRIPTION
Add an option so the user can specify the name of the config path argument.

I have extended the `add_config_path_arg` parameter of `ArgumentParser` to accept a string. If specified this determines the name of the argument, otherwise, it defaults to the previous value of `config_path`.

I have also added the `config_path` parameter to `ArgumentParser`'s docstrings, as it was missing previously.