### PR TITLE
Bugfix: fix optional positional arguments.

### DIFF
--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -272,7 +272,8 @@ class FieldWrapper(Wrapper):
             _arg_options.pop("metavar", None)
 
         elif utils.is_optional(self.type) or self.field.default is None:
-            _arg_options["required"] = False
+            if not self.field.metadata.get("positional"):
+                _arg_options["required"] = False
 
             if utils.is_optional(self.type):
                 type_arguments = utils.get_args(self.type)

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import pytest
 
+import simple_parsing
 from simple_parsing import ArgumentParser
 
 from .testutils import TestSetup
@@ -142,3 +143,14 @@ def test_optional_without_default():
 #     actual = SomeDataclass.setup(f"--some_attribute {passed_value}")
 #     assert actual.some_attribute == expected_value
 #     assert isinstance(actual.some_attribute, some_type)
+
+
+def test_optional_positional():
+    """Test when an argument is optional and positional."""
+
+    @dataclass
+    class Foo(TestSetup):
+        a: int | None = simple_parsing.field(positional=True, default=None)
+
+    assert Foo.setup("") == Foo(a=None)
+    assert Foo.setup("1") == Foo(a=1)


### PR DESCRIPTION
Optional positional argument previously raised an error with argparse:

```
TypeError: 'required' is an invalid argument for positionals
```