### PR TITLE
Feature: able to parse `Optional[Type]` field to `None` from command-line

### DIFF
--- a/simple_parsing/wrappers/field_parsing.py
+++ b/simple_parsing/wrappers/field_parsing.py
@@ -200,10 +200,14 @@ def parse_optional(t: type[T]) -> Callable[[Optional[Any]], Optional[T]]:
     parse = get_parsing_fn(t)
 
     def _parse_optional(val: Optional[Any]) -> Optional[T]:
-        return val if val is None else parse(val)
+        if val is None:
+            return val
+        elif type(val) is str and val == "None":
+            return None
+        else:
+            return parse(val)
 
     return _parse_optional
-
 
 def parse_tuple(tuple_item_types: tuple[type[T], ...]) -> Callable[[list[T]], tuple[T, ...]]:
     """Makes a parsing function for creating tuples from the command-line args.

--- a/test/test_optional.py
+++ b/test/test_optional.py
@@ -32,6 +32,26 @@ def test_optional_seed():
 
 
 @dataclass
+class Config2:
+    var_with_default: Optional[int] = 42
+
+
+def test_optional_with_default_value():
+    """Test that a value marked as Optional with a default value can be overridden to None.
+    """
+    parser = ArgumentParser()
+    parser.add_arguments(Config2, dest="config")
+
+    args = parser.parse_args("".split())
+    config: Config2 = args.config
+    assert config == Config2(var_with_default=42)
+
+    args = parser.parse_args("--var_with_default".split())
+    config: Config2 = args.config
+    assert config == Config2(var_with_default=None)
+
+
+@dataclass
 class Child:
     name: str = "Kevin"
     age: int = 12


### PR DESCRIPTION
Currently, if a field with type-hint `Optional[Type]` has a non-optional default value, there's no way to set it to `None` by parsing from the command line. E.g.

```
@dataclass
class Config2:
    var_with_default: Optional[int] = 42
```

```
$ ./run.py --var_with_default None
```

This PR adds this feature, specifically by parsing the string literal `"None"` into` None` for optional-typed fields.