### PR TITLE
fix: explicitely set version to 0.1.8 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = ["docstring-parser~=0.15", "typing-extensions>=4.5.0"]
 license = { file = "LICENSE" }
+version = "0.1.8"
 
 [project.optional-dependencies]
 yaml = ["pyyaml>=6.0.2"]


### PR DESCRIPTION
Add required version setting, otherwise can lead to build problems:
```
The Poetry configuration is invalid:
  - Either [project.version] or [tool.poetry.version] is required in package mode.
```