### PR TITLE
Fix subgroups typing

### DIFF
--- a/simple_parsing/helpers/subgroups.py
+++ b/simple_parsing/helpers/subgroups.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import functools
 import inspect
 import typing
+from collections.abc import Mapping
 from dataclasses import _MISSING_TYPE, MISSING
 from enum import Enum
 from logging import getLogger as get_logger
@@ -21,7 +22,7 @@ Key = TypeVar("Key", str, int, bool, Enum)
 
 @overload
 def subgroups(
-    subgroups: dict[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
+    subgroups: Mapping[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
     *args,
     default: Key | DataclassT,
     default_factory: _MISSING_TYPE = MISSING,
@@ -32,7 +33,7 @@ def subgroups(
 
 @overload
 def subgroups(
-    subgroups: dict[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
+    subgroups: Mapping[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
     *args,
     default: _MISSING_TYPE = MISSING,
     default_factory: type[DataclassT] | functools.partial[DataclassT],
@@ -43,7 +44,7 @@ def subgroups(
 
 @overload
 def subgroups(
-    subgroups: dict[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
+    subgroups: Mapping[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
     *args,
     default: _MISSING_TYPE = MISSING,
     default_factory: _MISSING_TYPE = MISSING,
@@ -53,7 +54,7 @@ def subgroups(
 
 
 def subgroups(
-    subgroups: dict[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
+    subgroups: Mapping[Key, DataclassT | type[DataclassT] | functools.partial[DataclassT]],
     *args,
     default: Key | DataclassT | _MISSING_TYPE = MISSING,
     default_factory: type[DataclassT] | functools.partial[DataclassT] | _MISSING_TYPE = MISSING,


### PR DESCRIPTION
# Issue
With pyright, the subgroups function always produces a type error (reportArgumentType).

Example:
```
from dataclasses import dataclass
from simple_parsing import subgroups


@dataclass
class A:
    pass

subgroups({"a": A})
          ^^^^^^^^
          Argument of type "dict[str, type[A]]" cannot be assigned to parameter "subgroups" of type "dict[Key@subgroups, DataclassT@subgroups | type[DataclassT@subgroups] | partial[DataclassT@subgroups]]" in function "subgroups"
```

PS. In a different project, the error was reported as:
```
No overloads for "subgroups" match the provided arguments
subgroups.py: Overload 1 is the closest match
```


# Solution

As noted in the [pyright docs](https://microsoft.github.io/pyright/#/typed-libraries?id=wide-vs-narrow-types), the `subgroups` function argument should be typed as Mapping[...] instead of dict[...] due to type variance: 
> Use Sequence rather than list, Mapping rather than dict, etc. Immutable containers allow for more flexibility because their type parameters are covariant rather than invariant. A parameter that is typed as Sequence[str | int] can accept a list[str | int], list[int], Sequence[str], and a Sequence[int]. But a parameter typed as list[str | int] is much more restrictive and accepts only a list[str | int].

The only limitation is that Mapping is read-only, therefore the `subgroups` function must not modify the contents of its `subgroups` argument, but this appears to already be the case with the current implementation.