### PR TITLE
Fix negative_option conflict in NESTED argument generation mode

### DIFF
--- a/simple_parsing/wrappers/field_wrapper.py
+++ b/simple_parsing/wrappers/field_wrapper.py
@@ -385,7 +385,7 @@ class FieldWrapper(Wrapper):
                 # NOTE: also pass the prefix to the boolean optional action, because it needs to add it
                 # to the generated negative flags as well.
                 _arg_options["action"] = BooleanOptionalAction
-                _arg_options["_conflict_prefix"] = self.prefix
+                _arg_options["_conflict_prefix"] = self.negative_option_prefix
 
         else:
             # "Plain" / simple argument.
@@ -658,6 +658,24 @@ class FieldWrapper(Wrapper):
     # @property
     # def prefix(self) -> str:
     #     return self._prefix
+
+    @property
+    def negative_option_prefix(self) -> str:
+        """Prefix to add to an explicit `negative_option` so it doesn't conflict.
+
+        In `ArgumentGenerationMode.FLAT`, conflicts are resolved by setting `self.prefix`, so that
+        is the prefix the negative option needs. In `ArgumentGenerationMode.NESTED`, the option
+        strings are built from `self.dest` instead of `self.prefix`, which stays empty, so the
+        prefix has to be recovered from the generated (dotted) option string, otherwise two fields
+        of the same dataclass type generate the same negative flag and argparse raises a conflict.
+        """
+        if self.prefix:
+            return self.prefix
+        for option_string in self.option_strings:
+            name = option_string.lstrip("-")
+            if "." in name:
+                return name.rsplit(".", 1)[0] + "."
+        return ""
 
     @property
     def aliases(self) -> list[str]:

--- a/test/test_bools.py
+++ b/test/test_bools.py
@@ -8,6 +8,7 @@ import pytest
 
 from simple_parsing import helpers
 from simple_parsing.helpers.fields import field, flag
+from simple_parsing.wrappers.field_wrapper import ArgumentGenerationMode
 
 from .testutils import (
     TestSetup,
@@ -305,6 +306,36 @@ def test_nested_bool_field_negative_option_conflict(default_value: bool):
     assert "--train.silent" in help_text
     assert "--valid.silent" in help_text
     assert "--silent" not in help_text
+
+
+@pytest.mark.parametrize("default_value", [True, False])
+def test_nested_bool_field_negative_option_conflict_nested_mode(default_value: bool):
+    """The negative option also needs a prefix with `ArgumentGenerationMode.NESTED`.
+
+    Reproduces https://github.com/lebrice/SimpleParsing/issues/364, where adding the same
+    dataclass twice raised `argparse.ArgumentError: conflicting option string: --silent`.
+    """
+
+    @dataclass
+    class Options:
+        verbose: bool = field(default=default_value, negative_option="silent")
+
+    @dataclass
+    class Config(TestSetup):
+        train: Options = field(default_factory=Options)
+        valid: Options = field(default_factory=Options)
+
+    help_text = Config.get_help_text(
+        argument_generation_mode=ArgumentGenerationMode.NESTED,
+    )
+    assert "--config.train.silent" in help_text
+    assert "--config.valid.silent" in help_text
+
+    config = Config.setup(
+        "--config.train.silent", argument_generation_mode=ArgumentGenerationMode.NESTED
+    )
+    assert config.train.verbose is False
+    assert config.valid.verbose is default_value
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
Closes #364

With `ArgumentGenerationMode.NESTED`, option strings are built from the field's `dest` instead of `prefix`, so `prefix` stays empty and the explicit `negative_option` never got a disambiguating prefix — adding the same dataclass twice made both fields emit the same negative flag and argparse raised `conflicting option string: --sym`. `negative_option_prefix` now falls back to the dotted part of the generated option string when `prefix` is empty; FLAT mode is unchanged.

Regression test added next to `test_nested_bool_field_negative_option_conflict` in `test/test_bools.py`: it fails with `ArgumentError` without the fix and passes with it.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
